### PR TITLE
Lookup game in database based on the rom name, if the MD5 does not succeed

### DIFF
--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -393,6 +393,26 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
                               error:&error];
     if (![results count])
     {
+        // Remove any extraneous stuff in the rom name such as (U) or (J) or [T+Eng] etc
+        NSRange parenRange = [[game title] rangeOfString:@"("];
+        NSRange bracketRange = [[game title] rangeOfString:@"["];
+        NSRange hyphenRange = [[game title] rangeOfString:@"-"];
+        NSUInteger gameTitleLen;
+        if (parenRange.length > 0 || bracketRange.length > 0 || hyphenRange.length > 0) {
+            gameTitleLen = MIN(hyphenRange.location, MIN(parenRange.location, bracketRange.location)) - 1;
+        } else {
+            gameTitleLen = [[game title] length];
+        }
+        
+        NSString *gameTitle = [[game title] substringToIndex:gameTitleLen];
+        NSString *system = [[[game systemIdentifier] pathExtension] uppercaseString];
+        
+        results =[self.gameDatabase executeQuery:[NSString stringWithFormat:@"SELECT DISTINCT releaseTitleName as 'gameTitle', releaseCoverFront as 'boxImageURL', releaseDescription as 'gameDescription', regionName as 'region' FROM ROMs rom LEFT JOIN RELEASES release USING (romID) LEFT JOIN REGIONS region on (regionLocalizedID=region.regionID) WHERE releaseTitleName >= '%@' and releaseTitleName <= '%@' || 'z' and regionName = 'USA' and TEMPsystemShortName = '%@'", gameTitle, gameTitle, system]
+                                                    error:&error];
+    }
+    
+    if (![results count])
+    {
         if (error)
         {
             DLog(@"Error looking up game info, %@", [error localizedDescription]);


### PR DESCRIPTION
This is necessary for ROMs that are not in the database. Right now this assumes USA for the region. While it is functional, there's probably a better way at getting the system than using TEMPsystemShortName in the SQL query.

Moving beyond this, it would be nice to show a popup that shows all the results based on the name, with their box art, and let the user pick the correctly matching game. Currently it just grabs the first result, like normal.