### PR TITLE
Some tvOS controller fixes

### DIFF
--- a/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
+++ b/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
@@ -428,7 +428,7 @@ static void FinalizeSamplesAudioCallback(void *)
 
 - (void)mapButtons
 {
-    for(int player = 1; player < 8; player++)
+    for(int player = 1; player <= 8; player++)
     {
         NSUInteger playerMask = player << 16;
 		

--- a/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
+++ b/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
@@ -418,17 +418,17 @@ static void FinalizeSamplesAudioCallback(void *)
 
 - (void)pushSNESButton:(PVSNESButton)button forPlayer:(NSInteger)player
 {
-    S9xReportButton((player << 16) | button, true);
+    S9xReportButton((player+1 << 16) | button, true);
 }
 
 - (void)releaseSNESButton:(PVSNESButton)button forPlayer:(NSInteger)player
 {
-    S9xReportButton((player << 16) | button, false);
+    S9xReportButton((player+1 << 16) | button, false);
 }
 
 - (void)mapButtons
 {
-    for(int player = 1; player <= 8; player++)
+    for(int player = 1; player < 8; player++)
     {
         NSUInteger playerMask = player << 16;
 		

--- a/Provenance/Controller/PVNESControllerViewController.m
+++ b/Provenance/Controller/PVNESControllerViewController.m
@@ -162,30 +162,37 @@
     }
 }
 
+
 - (void)controllerPressedDirection:(GCControllerDirectionPad *)dpad forPlayer:(NSInteger)player
 {
     PVNESEmulatorCore *nesCore = (PVNESEmulatorCore *)self.emulatorCore;
-    
-    [nesCore releaseNESButton:PVNESButtonUp forPlayer:player];
-    [nesCore releaseNESButton:PVNESButtonDown forPlayer:player];
-    [nesCore releaseNESButton:PVNESButtonLeft forPlayer:player];
-    [nesCore releaseNESButton:PVNESButtonRight forPlayer:player];
-    
-    if ([[dpad xAxis] value] > 0)
-    {
-        [nesCore pushNESButton:PVNESButtonRight forPlayer:player];
+    float xAxis = [[dpad xAxis] value];
+    float yAxis = [[dpad yAxis] value];
+    if (xAxis != 0 && fabsf(xAxis) > fabsf(yAxis)) {
+        if (xAxis > 0)
+        {
+            [nesCore pushNESButton:PVNESButtonRight forPlayer:player];
+        } else
+        if (xAxis < 0)
+        {
+            [nesCore pushNESButton:PVNESButtonLeft forPlayer:player];
+        }
+    } else  {
+            [nesCore releaseNESButton:PVNESButtonRight forPlayer:player];
+            [nesCore releaseNESButton:PVNESButtonLeft forPlayer:player];
     }
-    if ([[dpad xAxis] value] < 0)
-    {
-        [nesCore pushNESButton:PVNESButtonLeft forPlayer:player];
-    }
-    if ([[dpad yAxis] value] > 0)
-    {
-        [nesCore pushNESButton:PVNESButtonUp forPlayer:player];
-    }
-    if ([[dpad yAxis] value] < 0)
-    {
-        [nesCore pushNESButton:PVNESButtonDown forPlayer:player];
+    if (yAxis != 0 && fabsf(xAxis) <= fabsf(yAxis)) {
+        if (yAxis > 0)
+        {
+            [nesCore pushNESButton:PVNESButtonUp forPlayer:player];
+        } else
+        if (yAxis < 0)
+        {
+            [nesCore pushNESButton:PVNESButtonDown forPlayer:player];
+        }
+    } else  {
+        [nesCore releaseNESButton:PVNESButtonDown forPlayer:player];
+        [nesCore releaseNESButton:PVNESButtonUp forPlayer:player];
     }
 }
 


### PR DESCRIPTION
I haven't spent enough time to validate that these are correct in all cases, but in my testing on tvOS using a bluetooth controller, they work correctly and fix a couple issues.

One changes the way NES controller dpad events are processed, as zelda and other games were quite difficult to control, especially with the joystick.

The other change adds 1 to the player # for the SNES controller, as it appears to be 1 based. Without the change, the controller simply doesn't seem to work. 

It's entirely possible that these break the iOS onscreen controller, but at the very least they might be a starting point for fixing the issues I've noticed.