### PR TITLE
Diagonal controls from dpad and analog stick are not detected

### DIFF
--- a/Provenance/Controller/PVGBAControllerViewController.m
+++ b/Provenance/Controller/PVGBAControllerViewController.m
@@ -180,7 +180,7 @@
 
     float xAxis = [[dpad xAxis] value];
     float yAxis = [[dpad yAxis] value];
-    if (xAxis != 0 && fabsf(xAxis) > fabsf(yAxis))
+    if (xAxis != 0)
     {
         if (xAxis > 0)
         {
@@ -197,7 +197,7 @@
         [gbaCore releaseGBAButton:PVGBAButtonLeft forPlayer:player];
     }
     
-    if (yAxis != 0 && fabsf(xAxis) <= fabsf(yAxis))
+    if (yAxis != 0)
     {
         if (yAxis > 0)
         {

--- a/Provenance/Controller/PVGBControllerViewController.m
+++ b/Provenance/Controller/PVGBControllerViewController.m
@@ -168,7 +168,7 @@
 
     float xAxis = [[dpad xAxis] value];
     float yAxis = [[dpad yAxis] value];
-    if (xAxis != 0 && fabsf(xAxis) > fabsf(yAxis))
+    if (xAxis != 0)
     {
         if (xAxis > 0)
         {
@@ -185,7 +185,7 @@
         [gbCore releaseGBButton:PVGBButtonLeft];
     }
 
-    if (yAxis != 0 && fabsf(xAxis) <= fabsf(yAxis))
+    if (yAxis != 0)
     {
         if (yAxis > 0)
         {

--- a/Provenance/Controller/PVGenesisControllerViewController.m
+++ b/Provenance/Controller/PVGenesisControllerViewController.m
@@ -197,7 +197,7 @@
 
     float xAxis = [[dpad xAxis] value];
     float yAxis = [[dpad yAxis] value];
-    if (xAxis != 0 && fabsf(xAxis) > fabsf(yAxis))
+    if (xAxis != 0)
     {
         if (xAxis > 0)
         {
@@ -214,7 +214,7 @@
         [genesisCore releaseGenesisButton:PVGenesisButtonLeft forPlayer:player];
     }
 
-    if (yAxis != 0 && fabsf(xAxis) <= fabsf(yAxis))
+    if (yAxis != 0)
     {
         if (yAxis > 0)
         {

--- a/Provenance/Controller/PVNESControllerViewController.m
+++ b/Provenance/Controller/PVNESControllerViewController.m
@@ -168,7 +168,7 @@
     PVNESEmulatorCore *nesCore = (PVNESEmulatorCore *)self.emulatorCore;
     float xAxis = [[dpad xAxis] value];
     float yAxis = [[dpad yAxis] value];
-    if (xAxis != 0 && fabsf(xAxis) > fabsf(yAxis))
+    if (xAxis != 0)
     {
         if (xAxis > 0)
         {
@@ -185,7 +185,7 @@
         [nesCore releaseNESButton:PVNESButtonLeft forPlayer:player];
     }
     
-    if (yAxis != 0 && fabsf(xAxis) <= fabsf(yAxis))
+    if (yAxis != 0)
     {
         if (yAxis > 0)
         {

--- a/Provenance/Controller/PVSNESControllerViewController.m
+++ b/Provenance/Controller/PVSNESControllerViewController.m
@@ -194,7 +194,7 @@
 
     float xAxis = [[dpad xAxis] value];
     float yAxis = [[dpad yAxis] value];
-    if (xAxis != 0 && fabsf(xAxis) > fabsf(yAxis))
+    if (xAxis != 0)
     {
         if (xAxis > 0)
         {
@@ -211,7 +211,7 @@
         [snesCore releaseSNESButton:PVSNESButtonLeft forPlayer:player];
     }
     
-    if (yAxis != 0 && fabsf(xAxis) <= fabsf(yAxis))
+    if (yAxis != 0)
     {
         if (yAxis > 0)
         {


### PR DESCRIPTION
Diagonal controls (i.e. direction UP and Right at the same time) are being detected as either an horizontal or a vertical direction.

The following code is causing the issue by skipping pressed direction:
```
&& fabsf(xAxis) > fabsf(yAxis)
&& fabsf(xAxis) <= fabsf(yAxis)
```