### PR TITLE
Fix for iCade 8bitdo Nes30 controller directions

### DIFF
--- a/Provenance/Controller/iCade/iCadeReaderView.m
+++ b/Provenance/Controller/iCade/iCadeReaderView.m
@@ -22,8 +22,8 @@
 
 #import "iCadeReaderView.h"
 
-static const char *ON_STATES  = "wdxayhujikol";
-static const char *OFF_STATES = "eczqtrfnmpgv";
+static const char *ON_STATES  = "zdxqyhujikol";
+static const char *OFF_STATES = "ecwatrfn,pgv";
 
 @interface iCadeReaderView()
 


### PR DESCRIPTION
Directions fixed for the d-pad.
8Bitdo NES30 firmware v2.63