### PR TITLE
Fix grabbing ROM metadata for titles that include periods

### DIFF
--- a/Provenance/Game Library/PVGameImporter.m
+++ b/Provenance/Game Library/PVGameImporter.m
@@ -450,7 +450,7 @@
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             charSet = [NSMutableCharacterSet punctuationCharacterSet];
-            [charSet removeCharactersInString:@"-+&"];
+            [charSet removeCharactersInString:@"-+&."];
         });
         
         NSRange nonCharRange = [fileName rangeOfCharacterFromSet:charSet];

--- a/Provenance/Game Library/PVGameImporter.m
+++ b/Provenance/Game Library/PVGameImporter.m
@@ -450,7 +450,7 @@
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             charSet = [NSMutableCharacterSet punctuationCharacterSet];
-            [charSet removeCharactersInString:@"-+&."];
+            [charSet removeCharactersInString:@"-+&.'"];
         });
         
         NSRange nonCharRange = [fileName rangeOfCharacterFromSet:charSet];


### PR DESCRIPTION
For example, games such as B.O.B. were not grabbing the correct artwork.