### PR TITLE
Exposed Sega SG-1000 support

### DIFF
--- a/Provenance/Emulator/PVEmulatorConfiguration.h
+++ b/Provenance/Emulator/PVEmulatorConfiguration.h
@@ -43,6 +43,7 @@ extern NSString * const PVGBSystemIdentifier;
 extern NSString * const PVGBCSystemIdentifier;
 extern NSString * const PVNESSystemIdentifier;
 extern NSString * const PVFDSSystemIdentifier;
+extern NSString * const PVSG1000SystemIdentifier;
 
 @interface PVEmulatorConfiguration : NSObject
 

--- a/Provenance/Emulator/PVEmulatorConfiguration.m
+++ b/Provenance/Emulator/PVEmulatorConfiguration.m
@@ -56,6 +56,8 @@ NSString * const PVGBSystemIdentifier = @"com.provenance.gb";
 NSString * const PVGBCSystemIdentifier = @"com.provenance.gbc";
 NSString * const PVNESSystemIdentifier = @"com.provenance.nes";
 NSString * const PVFDSSystemIdentifier = @"com.provenance.fds";
+NSString * const PVSG1000SystemIdentifier = @"com.provenance.sg1000";
+
 
 @interface PVEmulatorConfiguration ()
 
@@ -102,7 +104,8 @@ NSString * const PVFDSSystemIdentifier = @"com.provenance.fds";
 	if ([systemID isEqualToString:PVGenesisSystemIdentifier] ||
         [systemID isEqualToString:PVGameGearSystemIdentifier] ||
         [systemID isEqualToString:PVMasterSystemSystemIdentifier] ||
-        [systemID isEqualToString:PVSegaCDSystemIdentifier])
+        [systemID isEqualToString:PVSegaCDSystemIdentifier] ||
+        [systemID isEqualToString:PVSG1000SystemIdentifier])
 	{
 		core = [[PVGenesisEmulatorCore alloc] init];
 	}
@@ -135,7 +138,8 @@ NSString * const PVFDSSystemIdentifier = @"com.provenance.fds";
     if ([systemID isEqualToString:PVGenesisSystemIdentifier] ||
         [systemID isEqualToString:PVGameGearSystemIdentifier] ||
         [systemID isEqualToString:PVMasterSystemSystemIdentifier] ||
-        [systemID isEqualToString:PVSegaCDSystemIdentifier])
+        [systemID isEqualToString:PVSegaCDSystemIdentifier] ||
+        [systemID isEqualToString:PVSG1000SystemIdentifier])
 	{
 		controller = [[PVGenesisControllerViewController alloc] initWithControlLayout:[self controllerLayoutForSystem:systemID] systemIdentifier:systemID];
 	}

--- a/Provenance/Resources/systems.plist
+++ b/Provenance/Resources/systems.plist
@@ -745,5 +745,53 @@
 			</dict>
 		</array>
 	</dict>
+	<dict>
+		<key>PVSystemName</key>
+		<string>Sega SG-1000</string>
+		<key>PVShortSystemName</key>
+		<string>SG-1000</string>
+		<key>PVSystemIdentifier</key>
+		<string>com.provenance.sg1000</string>
+		<key>PVDatabaseID</key>
+		<string>33</string>
+		<key>PVSupportedExtensions</key>
+		<array>
+			<string>sg</string>
+		</array>
+		<key>PVControlLayout</key>
+		<array>
+			<dict>
+				<key>PVControlType</key>
+				<string>PVButtonGroup</string>
+				<key>PVControlSize</key>
+				<string>{212,160}</string>
+				<key>PVGroupedButtons</key>
+				<array>
+					<dict>
+						<key>PVControlType</key>
+						<string>PVButton</string>
+						<key>PVControlTitle</key>
+						<string>1</string>
+						<key>PVControlFrame</key>
+						<string>{{76,84},{60,60}}</string>
+					</dict>
+					<dict>
+						<key>PVControlType</key>
+						<string>PVButton</string>
+						<key>PVControlTitle</key>
+						<string>2</string>
+						<key>PVControlFrame</key>
+						<string>{{144,76},{60,60}}</string>
+					</dict>
+				</array>
+			</dict>
+			<dict>
+				<key>PVControlType</key>
+				<string>PVDPad</string>
+				<key>PVControlSize</key>
+				<string>{180,180}</string>
+			</dict>
+		</array>
+	</dict>
 </array>
 </plist>

--- a/Provenance/Resources/systems.plist
+++ b/Provenance/Resources/systems.plist
@@ -753,7 +753,7 @@
 		<key>PVSystemIdentifier</key>
 		<string>com.provenance.sg1000</string>
 		<key>PVDatabaseID</key>
-		<string>33</string>
+		<string>34</string>
 		<key>PVSupportedExtensions</key>
 		<array>
 			<string>sg</string>

--- a/README.mdown
+++ b/README.mdown
@@ -16,8 +16,9 @@ I was looking for a word with a similar meaning to Genesis and came across Prove
 ###Currently Supported Emulators:
 
 - Sega
-    - Genesis / Mega Drive
+    - SG-1000
     - Master System
+    - Genesis / Mega Drive
     - MegaCD [See wiki](https://github.com/jasarien/Provenance/wiki/Sega-MegaCD-Instructions)
     - Game Gear
 - Nintendo


### PR DESCRIPTION
https://en.wikipedia.org/wiki/SG-1000
Genesis Plus GX has support for it, so why not expose it. I've tested this and it works.

The only thing I don't quite understand is what PVDatabaseID should be set to in systems.plist for this system.  It is currently 33, the same as Sega Genesis. Let me know what it should be and I can update it to the correct value.