### PR TITLE
Add controller mapping for SteelSeries Free

### DIFF
--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		E4F9369A1B50829F009403C5 /* PViCade8BitdoController.m in Sources */ = {isa = PBXBuildFile; fileRef = E4F936991B50829F009403C5 /* PViCade8BitdoController.m */; };
 		E4F9369D1B50BF3B009403C5 /* PViCadeControllerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E4F9369C1B50BF3B009403C5 /* PViCadeControllerViewController.m */; };
 		E4F936A01B50C95E009403C5 /* kICadeControllerSetting.m in Sources */ = {isa = PBXBuildFile; fileRef = E4F9369F1B50C95E009403C5 /* kICadeControllerSetting.m */; };
+		F432119A1BFB6AB300387909 /* PViCadeSteelSeriesController.m in Sources */ = {isa = PBXBuildFile; fileRef = F43211991BFB6AB300387909 /* PViCadeSteelSeriesController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -491,6 +492,8 @@
 		E4F9369C1B50BF3B009403C5 /* PViCadeControllerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PViCadeControllerViewController.m; sourceTree = "<group>"; };
 		E4F9369E1B50C0D8009403C5 /* kICadeControllerSetting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = kICadeControllerSetting.h; sourceTree = "<group>"; };
 		E4F9369F1B50C95E009403C5 /* kICadeControllerSetting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = kICadeControllerSetting.m; sourceTree = "<group>"; };
+		F43211981BFB6AB300387909 /* PViCadeSteelSeriesController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PViCadeSteelSeriesController.h; sourceTree = "<group>"; };
+		F43211991BFB6AB300387909 /* PViCadeSteelSeriesController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PViCadeSteelSeriesController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1042,6 +1045,8 @@
 				E41448901B34B9600056D80A /* PViCadeController.m */,
 				E4F936981B50829F009403C5 /* PViCade8BitdoController.h */,
 				E4F936991B50829F009403C5 /* PViCade8BitdoController.m */,
+				F43211981BFB6AB300387909 /* PViCadeSteelSeriesController.h */,
+				F43211991BFB6AB300387909 /* PViCadeSteelSeriesController.m */,
 				E41448921B34BBAB0056D80A /* PViCadeReader.h */,
 				E41448931B34BBAB0056D80A /* PViCadeReader.m */,
 				E41448951B34C4080056D80A /* PViCadeGamepadButtonInput.h */,
@@ -1211,6 +1216,7 @@
 				1A3D40A817B2DCE4004DFFFC /* PVAppDelegate.m in Sources */,
 				1AABE0D01ABE3E5900FF6AEF /* PVGBControllerViewController.m in Sources */,
 				1A3FD78E1AC7744100F8C23C /* MBProgressHUD.m in Sources */,
+				F432119A1BFB6AB300387909 /* PViCadeSteelSeriesController.m in Sources */,
 				378F4A071B63D7CD0065FA39 /* GCDWebServerMultiPartFormRequest.m in Sources */,
 				423BB97F17DD46BC0048F457 /* NSData+Hashing.m in Sources */,
 				378F4A031B63D7CD0065FA39 /* GCDWebServerRequest.m in Sources */,

--- a/Provenance/Controller/iCade/PViCadeControllerViewController.m
+++ b/Provenance/Controller/iCade/PViCadeControllerViewController.m
@@ -34,7 +34,7 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return 3;
+    return kICadeControllerSetting_Count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/Provenance/Controller/iCade/PViCadeSteelSeriesController.h
+++ b/Provenance/Controller/iCade/PViCadeSteelSeriesController.h
@@ -1,0 +1,13 @@
+//
+//  PViCadeSteelSeriesController.h
+//  Provenance
+//
+//  Created by Simon Frost on 17/11/2015.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "PViCadeController.h"
+
+@interface PViCadeSteelSeriesController : PViCadeController
+
+@end

--- a/Provenance/Controller/iCade/PViCadeSteelSeriesController.m
+++ b/Provenance/Controller/iCade/PViCadeSteelSeriesController.m
@@ -1,0 +1,99 @@
+//
+//  PViCadeSteelSeriesController.m
+//  Provenance
+//
+//  Created by Simon Frost on 17/11/2015.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "PViCadeSteelSeriesController.h"
+#import "PViCadeGamepad.h"
+#import "PViCadeGamepadButtonInput.h"
+#import "PViCadeGamepadDirectionPad.h"
+
+@implementation PViCadeSteelSeriesController
+
+-(instancetype) init {
+    if (self = [super init]) {
+        __unsafe_unretained PViCadeController* weakSelf = self;
+        self.reader.buttonDown = ^(iCadeState button) {
+            switch (button) {
+                case iCadeButtonA:
+                    [[weakSelf.iCadeGamepad buttonX] buttonPressed];
+                    break;
+                case iCadeButtonB:
+                    [[weakSelf.iCadeGamepad buttonA] buttonPressed];
+                    break;
+                case iCadeButtonC:
+                    [[weakSelf.iCadeGamepad buttonY] buttonPressed];
+                    break;
+                case iCadeButtonD:
+                    [[weakSelf.iCadeGamepad buttonB] buttonPressed];
+                    break;
+                case iCadeButtonE:
+                    [[weakSelf.iCadeGamepad leftShoulder] buttonPressed];
+                    break;
+                case iCadeButtonF:
+                    [[weakSelf.iCadeGamepad rightShoulder] buttonPressed];
+                    break;
+                case iCadeButtonG:
+                    [[weakSelf.iCadeGamepad rightTrigger] buttonPressed];
+                    break;
+                case iCadeButtonH:
+                    [[weakSelf.iCadeGamepad leftTrigger] buttonPressed];
+                    break;
+                case iCadeJoystickDown:
+                case iCadeJoystickLeft:
+                case iCadeJoystickRight:
+                case iCadeJoystickUp:
+                    [[weakSelf.iCadeGamepad dpad] padChanged];
+                    break;
+                default:
+                    break;
+            }
+            if (weakSelf.controllerPressedAnyKey) {
+                weakSelf.controllerPressedAnyKey(weakSelf);
+            }
+        };
+        
+        self.reader.buttonUp = ^(iCadeState button) {
+            switch (button) {
+                case iCadeButtonA:
+                    [[weakSelf.iCadeGamepad buttonX] buttonReleased];
+                    break;
+                case iCadeButtonB:
+                    [[weakSelf.iCadeGamepad buttonA] buttonReleased];
+                    break;
+                case iCadeButtonC:
+                    [[weakSelf.iCadeGamepad buttonY] buttonReleased];
+                    break;
+                case iCadeButtonD:
+                    [[weakSelf.iCadeGamepad buttonB] buttonReleased];
+                    break;
+                case iCadeButtonE:
+                    [[weakSelf.iCadeGamepad leftShoulder] buttonReleased];
+                    break;
+                case iCadeButtonF:
+                    [[weakSelf.iCadeGamepad rightShoulder] buttonReleased];
+                    break;
+                case iCadeButtonG:
+                    [[weakSelf.iCadeGamepad rightTrigger] buttonReleased];
+                    break;
+                case iCadeButtonH:
+                    [[weakSelf.iCadeGamepad leftTrigger] buttonReleased];
+                    break;
+                case iCadeJoystickDown:
+                case iCadeJoystickLeft:
+                case iCadeJoystickRight:
+                case iCadeJoystickUp:
+                    [[weakSelf.iCadeGamepad dpad] padChanged];
+                    break;
+                default:
+                    break;
+            }
+        };
+    }
+    return self;
+}
+
+@end

--- a/Provenance/Controller/iCade/kICadeControllerSetting.h
+++ b/Provenance/Controller/iCade/kICadeControllerSetting.h
@@ -15,6 +15,8 @@ typedef NS_ENUM(NSUInteger, kICadeControllerSetting) {
     kICadeControllerSettingDisabled,
     kICadeControllerSettingStandard,
     kICadeControllerSetting8Bitdo,
+    kICadeControllerSettingSteelSeries,
+    kICadeControllerSetting_Count
 };
 
 NSString* kIcadeControllerSettingToString(kICadeControllerSetting value);

--- a/Provenance/Controller/iCade/kICadeControllerSetting.m
+++ b/Provenance/Controller/iCade/kICadeControllerSetting.m
@@ -8,6 +8,7 @@
 
 #include "kICadeControllerSetting.h"
 #import "PViCade8BitdoController.h"
+#import "PViCadeSteelSeriesController.h"
 
 
 NSString* kIcadeControllerSettingToString(kICadeControllerSetting value) {
@@ -21,6 +22,9 @@ NSString* kIcadeControllerSettingToString(kICadeControllerSetting value) {
             break;
         case kICadeControllerSetting8Bitdo:
             stringRepresentation = @"8bitdo Nes30 Controller";
+            break;
+        case kICadeControllerSettingSteelSeries:
+            stringRepresentation = @"SteelSeries Free Controller";
         default:
             break;
     }
@@ -39,6 +43,10 @@ PViCadeController* kIcadeControllerSettingToPViCadeController(kICadeControllerSe
             break;
         case kICadeControllerSetting8Bitdo:
             controller = [[PViCade8BitdoController alloc] init];
+            break;
+        case kICadeControllerSettingSteelSeries:
+            controller = [[PViCadeSteelSeriesController alloc] init];
+            break;
         default:
             break;
     }


### PR DESCRIPTION
This change adds a more appropriate controller mapping for the SteelSeries Free controller - the code is based on the iCade8Bitdo implementation. I set the buttons up to mirror the layout of the SNES pad as this most closely matches the physical layout of the controller, but tested with the Genesis emulator and it also works well.