### PR TITLE
tvOS Top Shelf

### DIFF
--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -217,6 +217,13 @@
 		42E63AE917E12ECE00FE7098 /* PVSNESControllerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 42E63AE817E12ECE00FE7098 /* PVSNESControllerViewController.m */; };
 		42E63F0617DE78AB005802B0 /* UIImage+Scaling.m in Sources */ = {isa = PBXBuildFile; fileRef = 42E63F0517DE78AB005802B0 /* UIImage+Scaling.m */; };
 		7556CF7A19DC15C1007F8F97 /* Default.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7556CF7919DC15C1007F8F97 /* Default.xib */; };
+		BE9FDCB91C210B9E0046DF0E /* TVServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9FDCB81C210B9E0046DF0E /* TVServices.framework */; };
+		BE9FDCBD1C210B9F0046DF0E /* ServiceProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BE9FDCBC1C210B9F0046DF0E /* ServiceProvider.m */; };
+		BE9FDCC11C210B9F0046DF0E /* TopShelf.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = BE9FDCB71C210B9E0046DF0E /* TopShelf.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BE9FDCC91C210C470046DF0E /* PVRecentGame+TopShelf.m in Sources */ = {isa = PBXBuildFile; fileRef = BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.m */; };
+		BE9FDCCA1C210CC20046DF0E /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AACCAE01BB60D8200DC21AE /* Realm.framework */; };
+		BE9FDCCB1C210CED0046DF0E /* PVRecentGame.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A9938A11BBB02590050A2B7 /* PVRecentGame.m */; };
+		BE9FDCCE1C211A220046DF0E /* PVGame.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A48697117C8C0DE0019F6D2 /* PVGame.m */; };
 		E414488B1B3125D90056D80A /* iCadeReaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = E41448891B3125D90056D80A /* iCadeReaderView.m */; };
 		E414488E1B3126190056D80A /* PViCadeGamepad.m in Sources */ = {isa = PBXBuildFile; fileRef = E414488D1B3126190056D80A /* PViCadeGamepad.m */; };
 		E41448911B34B9600056D80A /* PViCadeController.m in Sources */ = {isa = PBXBuildFile; fileRef = E41448901B34B9600056D80A /* PViCadeController.m */; };
@@ -237,6 +244,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1A3D409317B2DCE4004DFFFC;
 			remoteInfo = Provenance;
+		};
+		BE9FDCBF1C210B9F0046DF0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A3D408C17B2DCE4004DFFFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BE9FDCB61C210B9E0046DF0E;
+			remoteInfo = TopShelf;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -261,6 +275,17 @@
 				1AAE7D431BC870A8003066C0 /* Realm.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BE9FDCC61C210B9F0046DF0E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				BE9FDCC11C210B9F0046DF0E /* TopShelf.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -464,6 +489,15 @@
 		42E63F0417DE78AB005802B0 /* UIImage+Scaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Scaling.h"; sourceTree = "<group>"; };
 		42E63F0517DE78AB005802B0 /* UIImage+Scaling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Scaling.m"; sourceTree = "<group>"; };
 		7556CF7919DC15C1007F8F97 /* Default.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Default.xib; sourceTree = "<group>"; };
+		BE9FDCB71C210B9E0046DF0E /* TopShelf.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TopShelf.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE9FDCB81C210B9E0046DF0E /* TVServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TVServices.framework; path = Library/Frameworks/TVServices.framework; sourceTree = DEVELOPER_DIR; };
+		BE9FDCBB1C210B9F0046DF0E /* ServiceProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceProvider.h; sourceTree = "<group>"; };
+		BE9FDCBC1C210B9F0046DF0E /* ServiceProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ServiceProvider.m; sourceTree = "<group>"; };
+		BE9FDCBE1C210B9F0046DF0E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BE9FDCC71C210C470046DF0E /* PVRecentGame+TopShelf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PVRecentGame+TopShelf.h"; sourceTree = "<group>"; };
+		BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PVRecentGame+TopShelf.m"; sourceTree = "<group>"; };
+		BE9FDCCC1C21109B0046DF0E /* Provenance.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Provenance.entitlements; sourceTree = "<group>"; };
+		BE9FDCCD1C21194B0046DF0E /* TopShelf.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TopShelf.entitlements; sourceTree = "<group>"; };
 		E41448881B3125D90056D80A /* iCadeReaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iCadeReaderView.h; sourceTree = "<group>"; };
 		E41448891B3125D90056D80A /* iCadeReaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iCadeReaderView.m; sourceTree = "<group>"; };
 		E414488A1B3125D90056D80A /* iCadeState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iCadeState.h; sourceTree = "<group>"; };
@@ -560,6 +594,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE9FDCB41C210B9E0046DF0E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BE9FDCB91C210B9E0046DF0E /* TVServices.framework in Frameworks */,
+				BE9FDCCA1C210CC20046DF0E /* Realm.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -628,6 +671,7 @@
 				1A3D409D17B2DCE4004DFFFC /* Provenance */,
 				1AD9AA361ACC988F00EC87A0 /* Provenance Tests */,
 				1AD481B51BA350A400FDA50A /* ProvenanceTV */,
+				BE9FDCBA1C210B9E0046DF0E /* TopShelf */,
 				1A3D409617B2DCE4004DFFFC /* Frameworks */,
 				1AACCADD1BB60D8200DC21AE /* Realm-iOS */,
 				1AACCADF1BB60D8200DC21AE /* Realm-tvOS */,
@@ -641,6 +685,7 @@
 				1A3D409417B2DCE4004DFFFC /* Provenance.app */,
 				1AD9AA351ACC988F00EC87A0 /* Provenance Tests.xctest */,
 				1AD481B41BA350A400FDA50A /* Provenance.app */,
+				BE9FDCB71C210B9E0046DF0E /* TopShelf.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -650,6 +695,7 @@
 			children = (
 				1A4DF9F91C0E411500DDBC20 /* iOS */,
 				1A4DF9F81C0E40FE00DDBC20 /* tvOS */,
+				BE9FDCB81C210B9E0046DF0E /* TVServices.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -903,6 +949,7 @@
 		1AD481B51BA350A400FDA50A /* ProvenanceTV */ = {
 			isa = PBXGroup;
 			children = (
+				BE9FDCCC1C21109B0046DF0E /* Provenance.entitlements */,
 				1AACCAEB1BB61D5600DC21AE /* PVTVSplitViewController.h */,
 				1AACCAEC1BB61D5600DC21AE /* PVTVSplitViewController.m */,
 				1ACE9A081BACBC9E00C72AA5 /* PVTVSettingsViewController.h */,
@@ -1032,6 +1079,19 @@
 			path = Reachability;
 			sourceTree = "<group>";
 		};
+		BE9FDCBA1C210B9E0046DF0E /* TopShelf */ = {
+			isa = PBXGroup;
+			children = (
+				BE9FDCCD1C21194B0046DF0E /* TopShelf.entitlements */,
+				BE9FDCBB1C210B9F0046DF0E /* ServiceProvider.h */,
+				BE9FDCBC1C210B9F0046DF0E /* ServiceProvider.m */,
+				BE9FDCBE1C210B9F0046DF0E /* Info.plist */,
+				BE9FDCC71C210C470046DF0E /* PVRecentGame+TopShelf.h */,
+				BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.m */,
+			);
+			path = TopShelf;
+			sourceTree = "<group>";
+		};
 		E41448871B3125D90056D80A /* iCade */ = {
 			isa = PBXGroup;
 			children = (
@@ -1091,10 +1151,12 @@
 				1AD481B11BA350A400FDA50A /* Frameworks */,
 				1AD481B21BA350A400FDA50A /* Resources */,
 				1AACCAE61BB60DB500DC21AE /* Embed Frameworks */,
+				BE9FDCC61C210B9F0046DF0E /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				BE9FDCC01C210B9F0046DF0E /* PBXTargetDependency */,
 			);
 			name = ProvenanceTV;
 			productName = ProvenanceTV;
@@ -1119,6 +1181,23 @@
 			productReference = 1AD9AA351ACC988F00EC87A0 /* Provenance Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		BE9FDCB61C210B9E0046DF0E /* TopShelf */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BE9FDCC51C210B9F0046DF0E /* Build configuration list for PBXNativeTarget "TopShelf" */;
+			buildPhases = (
+				BE9FDCB31C210B9E0046DF0E /* Sources */,
+				BE9FDCB41C210B9E0046DF0E /* Frameworks */,
+				BE9FDCB51C210B9E0046DF0E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TopShelf;
+			productName = TopShelf;
+			productReference = BE9FDCB71C210B9E0046DF0E /* TopShelf.appex */;
+			productType = "com.apple.product-type.tv-app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1134,10 +1213,25 @@
 					};
 					1AD481B31BA350A400FDA50A = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = HWU4UAU436;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 					1AD9AA341ACC988F00EC87A0 = {
 						CreatedOnToolsVersion = 6.2;
 						TestTargetID = 1A3D409317B2DCE4004DFFFC;
+					};
+					BE9FDCB61C210B9E0046DF0E = {
+						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = HWU4UAU436;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -1157,6 +1251,7 @@
 				1A3D409317B2DCE4004DFFFC /* Provenance */,
 				1AD481B31BA350A400FDA50A /* ProvenanceTV */,
 				1AD9AA341ACC988F00EC87A0 /* Provenance Tests */,
+				BE9FDCB61C210B9E0046DF0E /* TopShelf */,
 			);
 		};
 /* End PBXProject section */
@@ -1198,6 +1293,13 @@
 			files = (
 				1A2B0E8C1AD187F4005FB77C /* testdata.txt in Resources */,
 				1AD9AA411ACC98A200EC87A0 /* systems.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BE9FDCB51C210B9E0046DF0E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1377,6 +1479,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE9FDCB31C210B9E0046DF0E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BE9FDCBD1C210B9F0046DF0E /* ServiceProvider.m in Sources */,
+				BE9FDCC91C210C470046DF0E /* PVRecentGame+TopShelf.m in Sources */,
+				BE9FDCCB1C210CED0046DF0E /* PVRecentGame.m in Sources */,
+				BE9FDCCE1C211A220046DF0E /* PVGame.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1384,6 +1497,11 @@
 			isa = PBXTargetDependency;
 			target = 1A3D409317B2DCE4004DFFFC /* Provenance */;
 			targetProxy = 1AD9AA511ACC9FA800EC87A0 /* PBXContainerItemProxy */;
+		};
+		BE9FDCC01C210B9F0046DF0E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BE9FDCB61C210B9E0046DF0E /* TopShelf */;
+			targetProxy = BE9FDCBF1C210B9F0046DF0E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1567,6 +1685,9 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = ProvenanceTV/Provenance.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1602,6 +1723,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamsoftonline.ProvenanceTV;
 				PRODUCT_NAME = Provenance;
+				PROVISIONING_PROFILE = "";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1620,6 +1742,9 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = ProvenanceTV/Provenance.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -1657,6 +1782,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamsoftonline.ProvenanceTV;
 				PRODUCT_NAME = Provenance;
+				PROVISIONING_PROFILE = "";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1675,6 +1801,9 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = ProvenanceTV/Provenance.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -1712,6 +1841,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamsoftonline.ProvenanceTV;
 				PRODUCT_NAME = Provenance;
+				PROVISIONING_PROFILE = "";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1947,6 +2077,118 @@
 			};
 			name = AdHoc;
 		};
+		BE9FDCC21C210B9F0046DF0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = TopShelf/TopShelf.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Realm-tvOS",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = TopShelf/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamsoftonline.ProvenanceTV.TopShelf;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Debug;
+		};
+		BE9FDCC31C210B9F0046DF0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = TopShelf/TopShelf.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Realm-tvOS",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = TopShelf/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamsoftonline.ProvenanceTV.TopShelf;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Release;
+		};
+		BE9FDCC41C210B9F0046DF0E /* AdHoc */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = TopShelf/TopShelf.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Realm-tvOS",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = TopShelf/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamsoftonline.ProvenanceTV.TopShelf;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = AdHoc;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1989,6 +2231,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		BE9FDCC51C210B9F0046DF0E /* Build configuration list for PBXNativeTarget "TopShelf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BE9FDCC21C210B9F0046DF0E /* Debug */,
+				BE9FDCC31C210B9F0046DF0E /* Release */,
+				BE9FDCC41C210B9F0046DF0E /* AdHoc */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -1236,7 +1236,7 @@
 						DevelopmentTeam = HWU4UAU436;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
-								enabled = 1;
+								enabled = 0;
 							};
 						};
 					};
@@ -1249,7 +1249,7 @@
 						DevelopmentTeam = HWU4UAU436;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
-								enabled = 1;
+								enabled = 0;
 							};
 						};
 					};
@@ -1713,7 +1713,6 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = ProvenanceTV/Provenance.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1770,7 +1769,6 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = ProvenanceTV/Provenance.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
@@ -1829,7 +1827,6 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = ProvenanceTV/Provenance.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
@@ -2114,7 +2111,6 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = TopShelf/TopShelf.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -2150,7 +2146,6 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = TopShelf/TopShelf.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
@@ -2188,7 +2183,6 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = TopShelf/TopShelf.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;

--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -217,6 +217,12 @@
 		42E63AE917E12ECE00FE7098 /* PVSNESControllerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 42E63AE817E12ECE00FE7098 /* PVSNESControllerViewController.m */; };
 		42E63F0617DE78AB005802B0 /* UIImage+Scaling.m in Sources */ = {isa = PBXBuildFile; fileRef = 42E63F0517DE78AB005802B0 /* UIImage+Scaling.m */; };
 		7556CF7A19DC15C1007F8F97 /* Default.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7556CF7919DC15C1007F8F97 /* Default.xib */; };
+		BE1E26671C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1E26661C2252CA00499BA0 /* PVEmulatorConstants.m */; };
+		BE1E26681C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1E26661C2252CA00499BA0 /* PVEmulatorConstants.m */; };
+		BE1E26691C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1E26661C2252CA00499BA0 /* PVEmulatorConstants.m */; };
+		BE1E266A1C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1E26661C2252CA00499BA0 /* PVEmulatorConstants.m */; };
+		BE1E266D1C22552800499BA0 /* PVAppConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1E266C1C22552800499BA0 /* PVAppConstants.m */; };
+		BE1E266E1C22552800499BA0 /* PVAppConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1E266C1C22552800499BA0 /* PVAppConstants.m */; };
 		BE9FDCB91C210B9E0046DF0E /* TVServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9FDCB81C210B9E0046DF0E /* TVServices.framework */; };
 		BE9FDCBD1C210B9F0046DF0E /* ServiceProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BE9FDCBC1C210B9F0046DF0E /* ServiceProvider.m */; };
 		BE9FDCC11C210B9F0046DF0E /* TopShelf.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = BE9FDCB71C210B9E0046DF0E /* TopShelf.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -224,6 +230,8 @@
 		BE9FDCCA1C210CC20046DF0E /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AACCAE01BB60D8200DC21AE /* Realm.framework */; };
 		BE9FDCCB1C210CED0046DF0E /* PVRecentGame.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A9938A11BBB02590050A2B7 /* PVRecentGame.m */; };
 		BE9FDCCE1C211A220046DF0E /* PVGame.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A48697117C8C0DE0019F6D2 /* PVGame.m */; };
+		BEC075CD1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = BEC075CC1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m */; };
+		BEC075CE1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = BEC075CC1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m */; };
 		E414488B1B3125D90056D80A /* iCadeReaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = E41448891B3125D90056D80A /* iCadeReaderView.m */; };
 		E414488E1B3126190056D80A /* PViCadeGamepad.m in Sources */ = {isa = PBXBuildFile; fileRef = E414488D1B3126190056D80A /* PViCadeGamepad.m */; };
 		E41448911B34B9600056D80A /* PViCadeController.m in Sources */ = {isa = PBXBuildFile; fileRef = E41448901B34B9600056D80A /* PViCadeController.m */; };
@@ -489,6 +497,10 @@
 		42E63F0417DE78AB005802B0 /* UIImage+Scaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Scaling.h"; sourceTree = "<group>"; };
 		42E63F0517DE78AB005802B0 /* UIImage+Scaling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Scaling.m"; sourceTree = "<group>"; };
 		7556CF7919DC15C1007F8F97 /* Default.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Default.xib; sourceTree = "<group>"; };
+		BE1E26651C2252CA00499BA0 /* PVEmulatorConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVEmulatorConstants.h; sourceTree = "<group>"; };
+		BE1E26661C2252CA00499BA0 /* PVEmulatorConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PVEmulatorConstants.m; sourceTree = "<group>"; };
+		BE1E266B1C22552800499BA0 /* PVAppConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVAppConstants.h; sourceTree = "<group>"; };
+		BE1E266C1C22552800499BA0 /* PVAppConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PVAppConstants.m; sourceTree = "<group>"; };
 		BE9FDCB71C210B9E0046DF0E /* TopShelf.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TopShelf.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE9FDCB81C210B9E0046DF0E /* TVServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TVServices.framework; path = Library/Frameworks/TVServices.framework; sourceTree = DEVELOPER_DIR; };
 		BE9FDCBB1C210B9F0046DF0E /* ServiceProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceProvider.h; sourceTree = "<group>"; };
@@ -498,6 +510,8 @@
 		BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PVRecentGame+TopShelf.m"; sourceTree = "<group>"; };
 		BE9FDCCC1C21109B0046DF0E /* Provenance.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Provenance.entitlements; sourceTree = "<group>"; };
 		BE9FDCCD1C21194B0046DF0E /* TopShelf.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TopShelf.entitlements; sourceTree = "<group>"; };
+		BEC075CB1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMRealmConfiguration+GroupConfig.h"; sourceTree = "<group>"; };
+		BEC075CC1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMRealmConfiguration+GroupConfig.m"; sourceTree = "<group>"; };
 		E41448881B3125D90056D80A /* iCadeReaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iCadeReaderView.h; sourceTree = "<group>"; };
 		E41448891B3125D90056D80A /* iCadeReaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iCadeReaderView.m; sourceTree = "<group>"; };
 		E414488A1B3125D90056D80A /* iCadeState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iCadeState.h; sourceTree = "<group>"; };
@@ -635,6 +649,8 @@
 				1A3D433A17B30BA3004DFFFC /* PVGLViewController.m */,
 				1A34C58817D53C9B0058E7D1 /* PVEmulatorConfiguration.h */,
 				1A34C58917D53C9B0058E7D1 /* PVEmulatorConfiguration.m */,
+				BE1E26651C2252CA00499BA0 /* PVEmulatorConstants.h */,
+				BE1E26661C2252CA00499BA0 /* PVEmulatorConstants.m */,
 			);
 			path = Emulator;
 			sourceTree = "<group>";
@@ -942,6 +958,8 @@
 				1A65D1C519917D55004E1777 /* UIImage+ImageEffects.m */,
 				1A9442551AD9A7AA008B32D4 /* NSDate+NSDate_SignificantDates.h */,
 				1A9442561AD9A7AA008B32D4 /* NSDate+NSDate_SignificantDates.m */,
+				BEC075CB1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.h */,
+				BEC075CC1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -958,6 +976,8 @@
 				1AD481C21BA350A400FDA50A /* TVAssets.xcassets */,
 				1AD481C41BA350A400FDA50A /* Info.plist */,
 				1AD481B61BA350A400FDA50A /* Supporting Files */,
+				BE1E266B1C22552800499BA0 /* PVAppConstants.h */,
+				BE1E266C1C22552800499BA0 /* PVAppConstants.m */,
 			);
 			path = ProvenanceTV;
 			sourceTree = "<group>";
@@ -1370,6 +1390,7 @@
 				1A48697817C8C0DE0019F6D2 /* PVMediaCache.m in Sources */,
 				1A48698317C8C1170019F6D2 /* NSString+Hashing.m in Sources */,
 				1A34C58A17D53C9B0058E7D1 /* PVEmulatorConfiguration.m in Sources */,
+				BE1E26671C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */,
 				1AD9AA301ACC871F00EC87A0 /* PVGameImporter.m in Sources */,
 				1A4850BB1AE1A6C500F7EF2E /* PVConflictViewController.m in Sources */,
 				378F4A151B63F2240065FA39 /* Reachability.m in Sources */,
@@ -1446,12 +1467,15 @@
 				1AD481B81BA350A400FDA50A /* main.m in Sources */,
 				1AD481CB1BA353F600FDA50A /* PVMediaCache.m in Sources */,
 				1A52098D1BADD4F900DAE6E3 /* PVControllerSelectionViewController.m in Sources */,
+				BEC075CD1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m in Sources */,
 				1AD481D51BA3542A00FDA50A /* GCDWebUploader.m in Sources */,
+				BE1E26681C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */,
 				1AD481F61BA3549F00FDA50A /* UIImage+ImageEffects.m in Sources */,
 				1AD481FA1BA354B100FDA50A /* PViCadeGamepad.m in Sources */,
 				1AD481DD1BA3544800FDA50A /* GCDWebServerFileRequest.m in Sources */,
 				1AD481D31BA3541E00FDA50A /* Reachability.m in Sources */,
 				1A9938A31BBB02590050A2B7 /* PVRecentGame.m in Sources */,
+				BE1E266D1C22552800499BA0 /* PVAppConstants.m in Sources */,
 				1AD481F41BA3549A00FDA50A /* NSData+Hashing.m in Sources */,
 				1AACCAED1BB61D5600DC21AE /* PVTVSplitViewController.m in Sources */,
 				1AD481D91BA3543B00FDA50A /* GCDWebServerFunctions.m in Sources */,
@@ -1465,6 +1489,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE1E26691C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */,
 				1AD9AA3A1ACC988F00EC87A0 /* Provenance_Tests.m in Sources */,
 				1AD9AA481ACC99C900EC87A0 /* PVSNESControllerViewController.m in Sources */,
 				1AD9AA441ACC999000EC87A0 /* PVGameImporter.m in Sources */,
@@ -1483,9 +1508,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE1E266A1C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */,
 				BE9FDCBD1C210B9F0046DF0E /* ServiceProvider.m in Sources */,
+				BEC075CE1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m in Sources */,
 				BE9FDCC91C210C470046DF0E /* PVRecentGame+TopShelf.m in Sources */,
 				BE9FDCCB1C210CED0046DF0E /* PVRecentGame.m in Sources */,
+				BE1E266E1C22552800499BA0 /* PVAppConstants.m in Sources */,
 				BE9FDCCE1C211A220046DF0E /* PVGame.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2240,6 +2268,7 @@
 				BE9FDCC41C210B9F0046DF0E /* AdHoc */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Provenance/Categories/RLMRealmConfiguration+GroupConfig.h
+++ b/Provenance/Categories/RLMRealmConfiguration+GroupConfig.h
@@ -1,0 +1,19 @@
+//
+//  RLMRealmConfiguration+GroupConfig.h
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-16.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import <Realm/Realm.h>
+
+@interface RLMRealmConfiguration (GroupConfig)
+
++ (RLMRealmConfiguration *)appGroupConfig;
+
++ (BOOL)supportsAppGroups;
+
++ (NSString *)appGroupPath;
+
+@end

--- a/Provenance/Categories/RLMRealmConfiguration+GroupConfig.m
+++ b/Provenance/Categories/RLMRealmConfiguration+GroupConfig.m
@@ -1,0 +1,37 @@
+//
+//  RLMRealmConfiguration+GroupConfig.m
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-16.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "RLMRealmConfiguration+GroupConfig.h"
+#import "PVAppConstants.h"
+
+@implementation RLMRealmConfiguration (GroupConfig)
+
++ (RLMRealmConfiguration *)appGroupConfig
+{
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.path = [self.appGroupPath stringByAppendingPathComponent:@"default.realm"];
+
+    return config;
+}
+
++ (BOOL)supportsAppGroups
+{
+    return PVAppGroupId.length && [self appGroupContainer];
+}
+
++ (NSURL *)appGroupContainer
+{
+    return [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:PVAppGroupId];
+}
+
++ (NSString *)appGroupPath
+{
+    return [self.appGroupContainer.path stringByAppendingPathComponent:@"Library/Caches/"];
+}
+
+@end

--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -16,6 +16,7 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import "PVControllerManager.h"
 #import "PVEmulatorCore.h"
+#import "PVEmulatorConstants.h"
 
 @interface PVControllerViewController ()
 

--- a/Provenance/Emulator/PVEmulatorConfiguration.h
+++ b/Provenance/Emulator/PVEmulatorConfiguration.h
@@ -10,41 +10,6 @@
 
 @class PVEmulatorCore, PVControllerViewController;
 
-extern NSString * const PVSystemNameKey;
-extern NSString * const PVShortSystemNameKey;
-extern NSString * const PVSystemIdentifierKey;
-extern NSString * const PVDatabaseIDKey;
-extern NSString * const PVUsesCDsKey;
-extern NSString * const PVRequiresBIOSKey;
-extern NSString * const PVBIOSNamesKey;
-extern NSString * const PVSupportedExtensionsKey;
-extern NSString * const PVControlLayoutKey;
-extern NSString * const PVControlTypeKey;
-extern NSString * const PVControlSizeKey;
-extern NSString * const PVGroupedButtonsKey;
-extern NSString * const PVControlFrameKey;
-extern NSString * const PVControlTitleKey;
-
-extern NSString * const PVButtonGroup;
-extern NSString * const PVButton;
-extern NSString * const PVDPad;
-extern NSString * const PVStartButton;
-extern NSString * const PVSelectButton;
-extern NSString * const PVLeftShoulderButton;
-extern NSString * const PVRightShoulderButton;
-
-extern NSString * const PVGenesisSystemIdentifier;
-extern NSString * const PVGameGearSystemIdentifier;
-extern NSString * const PVMasterSystemSystemIdentifier;
-extern NSString * const PVSegaCDSystemIdentifier;
-extern NSString * const PVSNESSystemIdentifier;
-extern NSString * const PVGBASystemIdentifier;
-extern NSString * const PVGBSystemIdentifier;
-extern NSString * const PVGBCSystemIdentifier;
-extern NSString * const PVNESSystemIdentifier;
-extern NSString * const PVFDSSystemIdentifier;
-extern NSString * const PVSG1000SystemIdentifier;
-
 @interface PVEmulatorConfiguration : NSObject
 
 + (PVEmulatorConfiguration *)sharedInstance;

--- a/Provenance/Emulator/PVEmulatorConfiguration.m
+++ b/Provenance/Emulator/PVEmulatorConfiguration.m
@@ -7,6 +7,7 @@
 //
 
 #import "PVEmulatorConfiguration.h"
+#import "PVEmulatorConstants.h"
 
 #import "PVGenesisEmulatorCore.h"
 #import "PVGenesisControllerViewController.h"
@@ -22,42 +23,6 @@
 
 #import "PVNESEmulatorCore.h"
 #import "PVNESControllerViewController.h"
-
-NSString * const PVSystemNameKey = @"PVSystemName";
-NSString * const PVShortSystemNameKey = @"PVShortSystemName";
-NSString * const PVSystemIdentifierKey = @"PVSystemIdentifier";
-NSString * const PVDatabaseIDKey = @"PVDatabaseID";
-NSString * const PVUsesCDsKey = @"PVUsesCDs";
-NSString * const PVRequiresBIOSKey = @"PVRequiresBIOS";
-NSString * const PVBIOSNamesKey = @"PVBIOSNames";
-NSString * const PVSupportedExtensionsKey = @"PVSupportedExtensions";
-NSString * const PVControlLayoutKey = @"PVControlLayout";
-NSString * const PVControlTypeKey = @"PVControlType";
-NSString * const PVControlSizeKey = @"PVControlSize";
-NSString * const PVGroupedButtonsKey = @"PVGroupedButtons";
-NSString * const PVControlFrameKey = @"PVControlFrame";
-NSString * const PVControlTitleKey = @"PVControlTitle";
-
-NSString * const PVButtonGroup = @"PVButtonGroup";
-NSString * const PVButton = @"PVButton";
-NSString * const PVDPad = @"PVDPad";
-NSString * const PVStartButton = @"PVStartButton";
-NSString * const PVSelectButton = @"PVSelectButton";
-NSString * const PVLeftShoulderButton = @"PVLeftShoulderButton";
-NSString * const PVRightShoulderButton = @"PVRightShoulderButton";
-
-NSString * const PVGenesisSystemIdentifier = @"com.provenance.genesis";
-NSString * const PVGameGearSystemIdentifier = @"com.provenance.gamegear";
-NSString * const PVMasterSystemSystemIdentifier = @"com.provenance.mastersystem";
-NSString * const PVSegaCDSystemIdentifier = @"com.provenance.segacd";
-NSString * const PVSNESSystemIdentifier = @"com.provenance.snes";
-NSString * const PVGBASystemIdentifier = @"com.provenance.gba";
-NSString * const PVGBSystemIdentifier = @"com.provenance.gb";
-NSString * const PVGBCSystemIdentifier = @"com.provenance.gbc";
-NSString * const PVNESSystemIdentifier = @"com.provenance.nes";
-NSString * const PVFDSSystemIdentifier = @"com.provenance.fds";
-NSString * const PVSG1000SystemIdentifier = @"com.provenance.sg1000";
-
 
 @interface PVEmulatorConfiguration ()
 

--- a/Provenance/Emulator/PVEmulatorConstants.h
+++ b/Provenance/Emulator/PVEmulatorConstants.h
@@ -1,0 +1,44 @@
+//
+//  PVEmulatorConstants.h
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-16.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+extern NSString * const PVSystemNameKey;
+extern NSString * const PVShortSystemNameKey;
+extern NSString * const PVSystemIdentifierKey;
+extern NSString * const PVDatabaseIDKey;
+extern NSString * const PVUsesCDsKey;
+extern NSString * const PVRequiresBIOSKey;
+extern NSString * const PVBIOSNamesKey;
+extern NSString * const PVSupportedExtensionsKey;
+extern NSString * const PVControlLayoutKey;
+extern NSString * const PVControlTypeKey;
+extern NSString * const PVControlSizeKey;
+extern NSString * const PVGroupedButtonsKey;
+extern NSString * const PVControlFrameKey;
+extern NSString * const PVControlTitleKey;
+
+extern NSString * const PVButtonGroup;
+extern NSString * const PVButton;
+extern NSString * const PVDPad;
+extern NSString * const PVStartButton;
+extern NSString * const PVSelectButton;
+extern NSString * const PVLeftShoulderButton;
+extern NSString * const PVRightShoulderButton;
+
+extern NSString * const PVGenesisSystemIdentifier;
+extern NSString * const PVGameGearSystemIdentifier;
+extern NSString * const PVMasterSystemSystemIdentifier;
+extern NSString * const PVSegaCDSystemIdentifier;
+extern NSString * const PVSNESSystemIdentifier;
+extern NSString * const PVGBASystemIdentifier;
+extern NSString * const PVGBSystemIdentifier;
+extern NSString * const PVGBCSystemIdentifier;
+extern NSString * const PVNESSystemIdentifier;
+extern NSString * const PVFDSSystemIdentifier;
+extern NSString * const PVSG1000SystemIdentifier;

--- a/Provenance/Emulator/PVEmulatorConstants.m
+++ b/Provenance/Emulator/PVEmulatorConstants.m
@@ -1,0 +1,45 @@
+//
+//  PVEmulatorConstants.m
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-16.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "PVEmulatorConstants.h"
+
+NSString * const PVSystemNameKey = @"PVSystemName";
+NSString * const PVShortSystemNameKey = @"PVShortSystemName";
+NSString * const PVSystemIdentifierKey = @"PVSystemIdentifier";
+NSString * const PVDatabaseIDKey = @"PVDatabaseID";
+NSString * const PVUsesCDsKey = @"PVUsesCDs";
+NSString * const PVRequiresBIOSKey = @"PVRequiresBIOS";
+NSString * const PVBIOSNamesKey = @"PVBIOSNames";
+NSString * const PVSupportedExtensionsKey = @"PVSupportedExtensions";
+NSString * const PVControlLayoutKey = @"PVControlLayout";
+NSString * const PVControlTypeKey = @"PVControlType";
+NSString * const PVControlSizeKey = @"PVControlSize";
+NSString * const PVGroupedButtonsKey = @"PVGroupedButtons";
+NSString * const PVControlFrameKey = @"PVControlFrame";
+NSString * const PVControlTitleKey = @"PVControlTitle";
+
+NSString * const PVButtonGroup = @"PVButtonGroup";
+NSString * const PVButton = @"PVButton";
+NSString * const PVDPad = @"PVDPad";
+NSString * const PVStartButton = @"PVStartButton";
+NSString * const PVSelectButton = @"PVSelectButton";
+NSString * const PVLeftShoulderButton = @"PVLeftShoulderButton";
+NSString * const PVRightShoulderButton = @"PVRightShoulderButton";
+
+NSString * const PVGenesisSystemIdentifier = @"com.provenance.genesis";
+NSString * const PVGameGearSystemIdentifier = @"com.provenance.gamegear";
+NSString * const PVMasterSystemSystemIdentifier = @"com.provenance.mastersystem";
+NSString * const PVSegaCDSystemIdentifier = @"com.provenance.segacd";
+NSString * const PVSNESSystemIdentifier = @"com.provenance.snes";
+NSString * const PVGBASystemIdentifier = @"com.provenance.gba";
+NSString * const PVGBSystemIdentifier = @"com.provenance.gb";
+NSString * const PVGBCSystemIdentifier = @"com.provenance.gbc";
+NSString * const PVNESSystemIdentifier = @"com.provenance.nes";
+NSString * const PVFDSSystemIdentifier = @"com.provenance.fds";
+NSString * const PVSG1000SystemIdentifier = @"com.provenance.sg1000";
+

--- a/Provenance/Game Library/PVGameImporter.m
+++ b/Provenance/Game Library/PVGameImporter.m
@@ -14,6 +14,7 @@
 #import "PVMediaCache.h"
 #import <Realm/Realm.h>
 #import "PVSynchronousURLSession.h"
+#import "PVEmulatorConstants.h"
 
 @interface PVGameImporter ()
 

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -81,11 +81,13 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         [[NSUserDefaults standardUserDefaults] registerDefaults:@{PVRequiresMigrationKey : @(YES)}];
         RLMRealmConfiguration *config = [[RLMRealmConfiguration alloc] init];
 #if TARGET_OS_TV
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        NSURL *container = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.muzi.provenance"];
+        NSString *path = [container.path stringByAppendingPathComponent:@"Library/Caches"];
 #else
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        NSString *path = paths.firstObject;
 #endif
-        [config setPath:[[paths firstObject] stringByAppendingPathComponent:@"default.realm"]];
+        [config setPath:[path stringByAppendingPathComponent:@"default.realm"]];
         [RLMRealmConfiguration setDefaultConfiguration:config];
         self.realm = [RLMRealm defaultRealm];
     }
@@ -112,14 +114,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 
 - (void)handleAppDidBecomeActive:(NSNotification *)note
 {
-#if !TARGET_OS_TV
-    PVAppDelegate *appDelegate = [[UIApplication sharedApplication] delegate];
-    if ([appDelegate shortcutItem])
-    {
-        [self loadRecentGameFromShortcut:[appDelegate shortcutItem]];
-        [appDelegate setShortcutItem:nil];
-    }
-#endif
+    [self loadGameFromShortcut];
 }
 
 - (void)viewDidLoad
@@ -189,14 +184,18 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         [self setUpGameLibrary];
     }
 
-#if !TARGET_OS_TV
+    [self loadGameFromShortcut];
+}
+
+- (void)loadGameFromShortcut
+{
     PVAppDelegate *appDelegate = [[UIApplication sharedApplication] delegate];
-    if ([appDelegate shortcutItem])
+    
+    if ([appDelegate shortcutItemMD5])
     {
-        [self loadRecentGameFromShortcut:[appDelegate shortcutItem]];
-        [appDelegate setShortcutItem:nil];
+        [self loadRecentGameFromShortcut:[appDelegate shortcutItemMD5]];
+        [appDelegate setShortcutItemMD5:nil];
     }
-#endif
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -785,7 +784,6 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 
 - (void)updateRecentGames:(PVGame *)game
 {
-#if !TARGET_OS_TV
     if (NSClassFromString(@"UIApplicationShortcutItem")) {
         RLMRealm *realm = [RLMRealm defaultRealm];
         [realm refresh];
@@ -813,48 +811,50 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         [realm addObject:newRecent];
         [realm commitWriteTransaction];
 
-
-        [[UIApplication sharedApplication] setShortcutItems:nil];
-        NSMutableArray *shortcuts = [NSMutableArray array];
-        for (PVRecentGame *recentGame in [recents sortedResultsUsingProperty:@"lastPlayedDate" ascending:NO])
-        {
-            if ([recentGame game])
-            {
-                UIApplicationShortcutItem *shortcut = [[UIApplicationShortcutItem alloc] initWithType:@"kRecentGameShortcut"
-                                                                                       localizedTitle:[[recentGame game] title]
-                                                                                    localizedSubtitle:[[PVEmulatorConfiguration sharedInstance] nameForSystemIdentifier:[[recentGame game] systemIdentifier]]
-                                                                                                 icon:nil
-                                                                                             userInfo:@{@"PVGameHash": [[recentGame game] md5Hash]}];
-                [shortcuts addObject:shortcut];
-            }
-            else
-            {
-                [realm beginWriteTransaction];
-                [realm deleteObject:recentGame];
-                [realm commitWriteTransaction];
-            }
-        }
-        
-        [[UIApplication sharedApplication] setShortcutItems:shortcuts];
+        [self registerRecentGames:recents];
     }
-#endif
 }
 
-#if !TARGET_OS_TV
-- (void)loadRecentGameFromShortcut:(UIApplicationShortcutItem *)shortcut
+- (void)registerRecentGames:(RLMResults *)recents
 {
-    if ([[shortcut type] isEqualToString:@"kRecentGameShortcut"])
+#if !TARGET_OS_TV
+
+    NSMutableArray *shortcuts = [NSMutableArray array];
+    RLMRealm *realm = [RLMRealm defaultRealm];
+
+    for (PVRecentGame *recentGame in [recents sortedResultsUsingProperty:@"lastPlayedDate" ascending:NO])
     {
-        NSString *md5 = (NSString *)[shortcut userInfo][@"PVGameHash"];
-        if ([md5 length])
+        if ([recentGame game])
         {
-            PVRecentGame *recentGame = [[PVRecentGame objectsWithPredicate:[NSPredicate predicateWithFormat:@"game.md5Hash == %@", md5]] firstObject];
-            PVGame *game = [recentGame game];
-            [self loadGame:game];
+            UIApplicationShortcutItem *shortcut = [[UIApplicationShortcutItem alloc] initWithType:@"kRecentGameShortcut"
+                                                                                   localizedTitle:[[recentGame game] title]
+                                                                                localizedSubtitle:[[PVEmulatorConfiguration sharedInstance] nameForSystemIdentifier:[[recentGame game] systemIdentifier]]
+                                                                                             icon:nil
+                                                                                         userInfo:@{@"PVGameHash": [[recentGame game] md5Hash]}];
+            [shortcuts addObject:shortcut];
+        }
+        else
+        {
+            [realm beginWriteTransaction];
+            [realm deleteObject:recentGame];
+            [realm commitWriteTransaction];
         }
     }
-}
+    
+    [[UIApplication sharedApplication] setShortcutItems:shortcuts];
+    
 #endif
+}
+
+- (void)loadRecentGameFromShortcut:(NSString *)md5
+{
+    if ([md5 length])
+    {
+        PVRecentGame *recentGame = [[PVRecentGame objectsWithPredicate:[NSPredicate predicateWithFormat:@"game.md5Hash == %@", md5]] firstObject];
+        PVGame *game = [recentGame game];
+        [self loadGame:game];
+    }
+}
 
 - (void)longPressRecognized:(UILongPressGestureRecognizer *)recognizer
 {

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -33,6 +33,8 @@
 #import "PVWebServer.h"
 #import "Reachability.h"
 #import "PVControllerManager.h"
+#import "RLMRealmConfiguration+GroupConfig.h"
+#import "PVEmulatorConstants.h"
 
 NSString * const PVGameLibraryHeaderView = @"PVGameLibraryHeaderView";
 NSString * const kRefreshLibraryNotification = @"kRefreshLibraryNotification";
@@ -81,8 +83,14 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         [[NSUserDefaults standardUserDefaults] registerDefaults:@{PVRequiresMigrationKey : @(YES)}];
         RLMRealmConfiguration *config = [[RLMRealmConfiguration alloc] init];
 #if TARGET_OS_TV
-        NSURL *container = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.muzi.provenance"];
-        NSString *path = [container.path stringByAppendingPathComponent:@"Library/Caches"];
+        NSString *path = nil;
+        if ([RLMRealmConfiguration supportsAppGroups]) {
+            path = [RLMRealmConfiguration appGroupPath];
+        }
+        else {
+            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+            path = paths.firstObject;
+        }
 #else
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
         NSString *path = paths.firstObject;

--- a/Provenance/PVAppDelegate.h
+++ b/Provenance/PVAppDelegate.h
@@ -11,7 +11,7 @@
 @interface PVAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
-#if !TARGET_OS_TV
-@property (nonatomic, strong) UIApplicationShortcutItem *shortcutItem;
-#endif
+
+@property (nonatomic, strong) NSString *shortcutItemMD5;
+
 @end

--- a/Provenance/PVAppDelegate.m
+++ b/Provenance/PVAppDelegate.m
@@ -10,6 +10,10 @@
 #import "PVSettingsModel.h"
 #import "PVControllerManager.h"
 
+#if TARGET_OS_TV
+#import "PVAppConstants.h"
+#endif
+
 @interface PVAppDelegate ()
 
 @end
@@ -57,7 +61,9 @@
             DLog(@"Unable to move file from %@ to %@ because %@", sourcePath, destinationPath, [error localizedDescription]);
         }
     }
-    else if ([components.path isEqualToString:@"PlayController"] && [components.queryItems.firstObject.name isEqualToString:@"md5"]) {
+    else if ([components.path isEqualToString:PVGameControllerKey] &&
+             [components.queryItems.firstObject.name isEqualToString:PVGameMDSKey])
+    {
         self.shortcutItemMD5 = components.queryItems.firstObject.value;
     }
     

--- a/Provenance/PVAppDelegate.m
+++ b/Provenance/PVAppDelegate.m
@@ -61,11 +61,13 @@
             DLog(@"Unable to move file from %@ to %@ because %@", sourcePath, destinationPath, [error localizedDescription]);
         }
     }
+#if TARGET_OS_TV
     else if ([components.path isEqualToString:PVGameControllerKey] &&
-             [components.queryItems.firstObject.name isEqualToString:PVGameMDSKey])
+             [components.queryItems.firstObject.name isEqualToString:PVGameMD5Key])
     {
         self.shortcutItemMD5 = components.queryItems.firstObject.value;
     }
+#endif
     
     return YES;
 }

--- a/Provenance/PVAppDelegate.m
+++ b/Provenance/PVAppDelegate.m
@@ -22,45 +22,56 @@
 #if !TARGET_OS_TV
     if (NSClassFromString(@"UIApplicationShortcutItem")) {
         UIApplicationShortcutItem *shortcut = launchOptions[UIApplicationLaunchOptionsShortcutItemKey];
-        if (shortcut)
+        if ([[shortcut type] isEqualToString:@"kRecentGameShortcut"])
         {
-            self.shortcutItem = shortcut;
+            self.shortcutItemMD5 = (NSString *)[shortcut userInfo][@"PVGameHash"];
         }
     }
 #endif
+    
 	return YES;
 }
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options
 {
-	if (url && [url isFileURL])
-	{
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    
+    if (url && [url isFileURL])
+    {
 #if TARGET_OS_TV
-		NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
 #else
-		NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 #endif
         NSString *documentsDirectory = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
-		
-		NSString *sourcePath = [url path];
-		NSString *filename = [sourcePath lastPathComponent];
-		NSString *destinationPath = [[documentsDirectory stringByAppendingPathComponent:@"roms"] stringByAppendingPathComponent:filename];
-		
-		NSFileManager *fileManager = [NSFileManager defaultManager];
-		NSError *error = nil;
-		BOOL success = [fileManager moveItemAtPath:sourcePath toPath:destinationPath error:&error];
-		if (!success || error)
-		{
-			DLog(@"Unable to move file from %@ to %@ because %@", sourcePath, destinationPath, [error localizedDescription]);
-		}
-	}
-	
-	return YES;
+        
+        NSString *sourcePath = [url path];
+        NSString *filename = [sourcePath lastPathComponent];
+        NSString *destinationPath = [[documentsDirectory stringByAppendingPathComponent:@"roms"] stringByAppendingPathComponent:filename];
+        
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSError *error = nil;
+        BOOL success = [fileManager moveItemAtPath:sourcePath toPath:destinationPath error:&error];
+        if (!success || error)
+        {
+            DLog(@"Unable to move file from %@ to %@ because %@", sourcePath, destinationPath, [error localizedDescription]);
+        }
+    }
+    else if ([components.path isEqualToString:@"PlayController"] && [components.queryItems.firstObject.name isEqualToString:@"md5"]) {
+        self.shortcutItemMD5 = components.queryItems.firstObject.value;
+    }
+    
+    return YES;
 }
 
 #if !TARGET_OS_TV
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(nonnull void (^)(BOOL))completionHandler {
-    self.shortcutItem = shortcutItem;
+    
+    if ([[shortcutItem type] isEqualToString:@"kRecentGameShortcut"])
+    {
+        self.shortcutItemMD5 = (NSString *)[shortcutItem userInfo][@"PVGameHash"];
+    }
+    
     completionHandler(YES);
 }
 #endif

--- a/ProvenanceTV/PVAppConstants.h
+++ b/ProvenanceTV/PVAppConstants.h
@@ -1,0 +1,15 @@
+//
+//  PVAppConstants.h
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-16.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const PVAppGroupId;
+
+extern NSString *const PVGameControllerKey;
+extern NSString *const PVGameMDSKey;
+extern NSString *const PVAppURLKey;

--- a/ProvenanceTV/PVAppConstants.h
+++ b/ProvenanceTV/PVAppConstants.h
@@ -11,5 +11,5 @@
 extern NSString *const PVAppGroupId;
 
 extern NSString *const PVGameControllerKey;
-extern NSString *const PVGameMDSKey;
+extern NSString *const PVGameMD5Key;
 extern NSString *const PVAppURLKey;

--- a/ProvenanceTV/PVAppConstants.m
+++ b/ProvenanceTV/PVAppConstants.m
@@ -1,0 +1,15 @@
+//
+//  PVAppConstants.m
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-16.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "PVAppConstants.h"
+
+NSString *const PVAppGroupId = @"group.muzi.provenance";
+
+NSString *const PVGameControllerKey = @"PlayController";
+NSString *const PVGameMDSKey = @"md5";
+NSString *const PVAppURLKey = @"provenance";

--- a/ProvenanceTV/PVAppConstants.m
+++ b/ProvenanceTV/PVAppConstants.m
@@ -8,7 +8,7 @@
 
 #import "PVAppConstants.h"
 
-NSString *const PVAppGroupId = @"group.muzi.provenance";
+NSString *const PVAppGroupId = @"";
 
 NSString *const PVGameControllerKey = @"PlayController";
 NSString *const PVGameMDSKey = @"md5";

--- a/ProvenanceTV/PVAppConstants.m
+++ b/ProvenanceTV/PVAppConstants.m
@@ -11,5 +11,5 @@
 NSString *const PVAppGroupId = @"";
 
 NSString *const PVGameControllerKey = @"PlayController";
-NSString *const PVGameMDSKey = @"md5";
+NSString *const PVGameMD5Key = @"md5";
 NSString *const PVAppURLKey = @"provenance";

--- a/ProvenanceTV/Provenance.entitlements
+++ b/ProvenanceTV/Provenance.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.muzi.provenance</string>
-	</array>
-</dict>
+<dict/>
 </plist>

--- a/ProvenanceTV/Provenance.entitlements
+++ b/ProvenanceTV/Provenance.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.muzi.provenance</string>
+	</array>
+</dict>
+</plist>

--- a/TopShelf/Info.plist
+++ b/TopShelf/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>TopShelf</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,33 +15,27 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.6</string>
+	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleURLTypes</key>
-	<array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
 		<dict>
-			<key>CFBundleURLName</key>
-			<string>com.provenance</string>
-			<key>CFBundleURLSchemes</key>
+			<key>TVExtensionProtocols</key>
 			<array>
-				<string>provenance</string>
+				<string>TVTopShelfProvider</string>
 			</array>
 		</dict>
-	</array>
-	<key>CFBundleVersion</key>
-	<string>1.2.6</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.tv-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>ServiceProvider</string>
 	</dict>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/TopShelf/PVRecentGame+TopShelf.h
+++ b/TopShelf/PVRecentGame+TopShelf.h
@@ -1,0 +1,16 @@
+//
+//  PVRecentGame+TopShelf.h
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-15.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "PVRecentGame.h"
+@import TVServices;
+
+@interface PVRecentGame (TopShelf)
+
+- (TVContentItem *)contentItemWithIdentifier:(TVContentIdentifier *)containerIdentifier;
+
+@end

--- a/TopShelf/PVRecentGame+TopShelf.m
+++ b/TopShelf/PVRecentGame+TopShelf.m
@@ -7,12 +7,8 @@
 //
 
 #import "PVRecentGame+TopShelf.h"
-
-/* TODO
-- [ ] migrate DB to group container
-- [ ] test different emulators
-- [ ] gracefull fallback if no app group is specified
-*/
+#import "PVEmulatorConstants.h"
+#import "PVAppConstants.h"
 
 @implementation PVRecentGame (TopShelf)
 
@@ -23,7 +19,7 @@
     
     item.title = self.game.title;
     item.imageURL = [NSURL URLWithString:self.game.originalArtworkURL];
-    item.imageShape = TVContentItemImageShapeHDTV;
+    item.imageShape = self.imageType;
     item.displayURL = self.displayURL;
     item.lastAccessedDate = self.lastPlayedDate;
     
@@ -33,10 +29,25 @@
 - (NSURL *)displayURL
 {
     NSURLComponents *components = [[NSURLComponents alloc] init];
-    components.scheme = @"provenance";
-    components.path = @"PlayController";
-    components.queryItems = @[[[NSURLQueryItem alloc] initWithName:@"md5" value:self.game.md5Hash]];
+    components.scheme = PVAppURLKey;
+    components.path = PVGameControllerKey;
+    components.queryItems = @[[[NSURLQueryItem alloc] initWithName:PVGameMDSKey value:self.game.md5Hash]];
     
     return components.URL;
 }
+
+- (TVContentItemImageShape)imageType
+{
+    if ([self.game.systemIdentifier isEqualToString:PVNESSystemIdentifier] ||
+        [self.game.systemIdentifier isEqualToString:PVGenesisSystemIdentifier] ||
+        [self.game.systemIdentifier isEqualToString:PVMasterSystemSystemIdentifier]) {
+        return TVContentItemImageShapePoster;
+    }
+    else if ([self.game.systemIdentifier isEqualToString:PVGameGearSystemIdentifier]) {
+        return TVContentItemImageShapeSquare;
+    }
+
+    return TVContentItemImageShapeHDTV;
+}
+
 @end

--- a/TopShelf/PVRecentGame+TopShelf.m
+++ b/TopShelf/PVRecentGame+TopShelf.m
@@ -1,0 +1,42 @@
+//
+//  PVRecentGame+TopShelf.m
+//  Provenance
+//
+//  Created by David Muzi on 2015-12-15.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "PVRecentGame+TopShelf.h"
+
+/* TODO
+- [ ] migrate DB to group container
+- [ ] test different emulators
+- [ ] gracefull fallback if no app group is specified
+*/
+
+@implementation PVRecentGame (TopShelf)
+
+- (TVContentItem *)contentItemWithIdentifier:(TVContentIdentifier *)containerIdentifier
+{
+    TVContentIdentifier *identifier = [[TVContentIdentifier alloc] initWithIdentifier:self.game.md5Hash container:containerIdentifier];
+    TVContentItem *item = [[TVContentItem alloc] initWithContentIdentifier:identifier];
+    
+    item.title = self.game.title;
+    item.imageURL = [NSURL URLWithString:self.game.originalArtworkURL];
+    item.imageShape = TVContentItemImageShapeHDTV;
+    item.displayURL = self.displayURL;
+    item.lastAccessedDate = self.lastPlayedDate;
+    
+    return item;
+}
+
+- (NSURL *)displayURL
+{
+    NSURLComponents *components = [[NSURLComponents alloc] init];
+    components.scheme = @"provenance";
+    components.path = @"PlayController";
+    components.queryItems = @[[[NSURLQueryItem alloc] initWithName:@"md5" value:self.game.md5Hash]];
+    
+    return components.URL;
+}
+@end

--- a/TopShelf/PVRecentGame+TopShelf.m
+++ b/TopShelf/PVRecentGame+TopShelf.m
@@ -31,7 +31,7 @@
     NSURLComponents *components = [[NSURLComponents alloc] init];
     components.scheme = PVAppURLKey;
     components.path = PVGameControllerKey;
-    components.queryItems = @[[[NSURLQueryItem alloc] initWithName:PVGameMDSKey value:self.game.md5Hash]];
+    components.queryItems = @[[[NSURLQueryItem alloc] initWithName:PVGameMD5Key value:self.game.md5Hash]];
     
     return components.URL;
 }

--- a/TopShelf/ServiceProvider.h
+++ b/TopShelf/ServiceProvider.h
@@ -1,0 +1,16 @@
+//
+//  ServiceProvider.h
+//  TopShelf
+//
+//  Created by David Muzi on 2015-12-15.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <TVServices/TVServices.h>
+
+@interface ServiceProvider : NSObject <TVTopShelfProvider>
+
+
+@end
+

--- a/TopShelf/ServiceProvider.h
+++ b/TopShelf/ServiceProvider.h
@@ -14,7 +14,7 @@
  1. Enable App Groups on the TopShelf target, and specify an App Group ID
         Provenance Project -> TopShelf Target -> Capabilities Section -> App Groups
  2. Enable App Groups on the Provenance TV target, using the same App Group ID
- 3. Define the value for `PVAppGroupId` in `RLMRealmConfiguration+GroupConfig.m` to that App Group ID
+ 3. Define the value for `PVAppGroupId` in `PVAppConstants.m` to that App Group ID
  
  */
 

--- a/TopShelf/ServiceProvider.h
+++ b/TopShelf/ServiceProvider.h
@@ -9,8 +9,16 @@
 #import <Foundation/Foundation.h>
 #import <TVServices/TVServices.h>
 
-@interface ServiceProvider : NSObject <TVTopShelfProvider>
+/** Enabling Top Shelf
+ 
+ 1. Enable App Groups on the TopShelf target, and specify an App Group ID
+        Provenance Project -> TopShelf Target -> Capabilities Section -> App Groups
+ 2. Enable App Groups on the Provenance TV target, using the same App Group ID
+ 3. Define the value for `PVAppGroupId` in `RLMRealmConfiguration+GroupConfig.m` to that App Group ID
+ 
+ */
 
+@interface ServiceProvider : NSObject <TVTopShelfProvider>
 
 @end
 

--- a/TopShelf/ServiceProvider.m
+++ b/TopShelf/ServiceProvider.m
@@ -1,0 +1,57 @@
+//
+//  ServiceProvider.m
+//  TopShelf
+//
+//  Created by David Muzi on 2015-12-15.
+//  Copyright © 2015 James Addyman. All rights reserved.
+//
+
+#import "ServiceProvider.h"
+#import "PVRecentGame+TopShelf.h"
+@import Realm;
+
+@interface ServiceProvider ()
+
+@end
+
+@implementation ServiceProvider
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        NSURL *container = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.muzi.provenance"];
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.path = [container.path stringByAppendingPathComponent:@"Library/Caches/default.realm"];
+        [RLMRealmConfiguration setDefaultConfiguration:config];
+    }
+    return self;
+}
+
+#pragma mark - TVTopShelfProvider protocol
+
+- (TVTopShelfContentStyle)topShelfStyle {
+    // Return desired Top Shelf style.
+    return TVTopShelfContentStyleSectioned;
+}
+
+- (NSArray *)topShelfItems {
+    
+    TVContentIdentifier *identifier = [[TVContentIdentifier alloc] initWithIdentifier:@"id" container:nil];
+    TVContentItem *recentItems = [[TVContentItem alloc] initWithContentIdentifier:identifier];
+    recentItems.title = @"Recently Played";
+    
+    RLMResults *recents = [PVRecentGame allObjects];
+    id <NSFastEnumeration> recentGames = [recents sortedResultsUsingProperty:@"lastPlayedDate" ascending:NO];
+
+    NSMutableArray *items = [[NSMutableArray alloc] init];
+    
+    for (PVRecentGame *game in recentGames) {
+        [items addObject:[game contentItemWithIdentifier:identifier]];
+    }
+    
+    recentItems.topShelfItems = items;
+    
+    return @[recentItems];
+}
+
+@end

--- a/TopShelf/TopShelf.entitlements
+++ b/TopShelf/TopShelf.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.muzi.provenance</string>
-	</array>
-</dict>
+<dict/>
 </plist>

--- a/TopShelf/TopShelf.entitlements
+++ b/TopShelf/TopShelf.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.muzi.provenance</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Fix: https://github.com/jasarien/Provenance/issues/145

### What this does

This PR introduces the Top Shelf feature to the tvOS target by showing the recently played games, and deep-linking to them.

![simulator screen shot dec 16 2015 8 53 23 pm](https://cloud.githubusercontent.com/assets/1058176/11859900/77bb85d8-a43d-11e5-97c2-8edf2af96b55.png)

### Implementation

- Introduces the top shelf app extension
- Moves the Realm DB to a shared app group so the main app and the top shelf target can access it
- refactors a bunch of defines and duplicate logic into shared classes/categories
- add URLScheme to tvOS target

### To Test

 1. Enable App Groups on the TopShelf target, and specify an App Group ID
        Provenance Project -> TopShelf Target -> Capabilities Section -> App Groups
 2. Enable App Groups on the Provenance TV target, using the same App Group ID
 3. Define the value for `PVAppGroupId` in `PVAppConstants.m` to that App Group ID
 