### PR TITLE
Allow for Opacity 0 for Controller Overlay

### DIFF
--- a/Provenance/User Interface/Provenance.storyboard
+++ b/Provenance/User Interface/Provenance.storyboard
@@ -259,7 +259,7 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.29999999999999999" minValue="0.20000000000000001" maxValue="1" id="QsG-CC-wH8">
+                                                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.29999999999999999" minValue="0" maxValue="1" id="QsG-CC-wH8">
                                                     <rect key="frame" x="6" y="8" width="248" height="34"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                     <animations/>


### PR DESCRIPTION
When using a MFI Controller It is nice to be able to fully remove the controller overlay.