### PR TITLE
README.mdown 2016 fix & other changes to prevent comments on issues

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,5 +1,5 @@
 # Provenance
-An iOS Frontend for multiple emulators
+An iOS & tvOS Frontend for multiple emulators
 
 ###Building Provenance
 [See the instructions on the wiki](https://github.com/jasarien/Provenance/wiki/Building-Provenance) And follow them _to the letter_. Any issues raised that clearly demonstrate that the instructions haven't been followed will be closed.
@@ -13,7 +13,7 @@ I was looking for a word with a similar meaning to Genesis and came across Prove
 > **Noun**  
 > > The beginning of something's existence; something's origin.
 
-###Currently Supported Emulators:
+###Systems currently supported by Provenance:
 
 - Sega
     - SG-1000
@@ -24,7 +24,7 @@ I was looking for a word with a similar meaning to Genesis and came across Prove
 - Nintendo
     - NES
     - Famicom Disk System [See Wiki](https://github.com/jasarien/Provenance/wiki/Famicom-Disk-System-Instructions)
-    - SNES
+    - SNES (Super Nintendo)
     - Gameboy / Gameboy Color
     - Gameboy Advance
 
@@ -46,12 +46,19 @@ I was looking for a word with a similar meaning to Genesis and came across Prove
     - Download a ROM using Mobile Safari and import it into Provenance
 - iTunes File Sharing
     - Just drop ROMs into the app from iTunes on your Mac or PC
-- Uses [OpenVGDB](https://github.com/OpenVGDB/OpenVGDB) to look up game info and artwork. OpenVGDB is a database maintained by the OpenEmu Team.
+- Uses [OpenVGDB](https://github.com/OpenVGDB/OpenVGDB) to look up game information and artwork
+    - OpenVGDB is a database maintained by the OpenEmu Team and automatically downloads available information and artwork
+    - Custom artwork is also supported
 - Game library searching
 - Supports iOS 8+
-- 3D Touch shortcuts for recent games on iPhone 6S/Plus
+    - 3D Touch shortcuts for recent games on iPhone 6S/Plus
+- Supports Apple TV tvOS 9+
+    - TopShelf support
 
 Feel free to suggest/request features using the Issues page, but please read all issues (open *and* closed) before raising new ones to avoid duplicates.
+
+Please note that this is an open source project done in the free time of the author and contributors and new features and new emulator cores may take time.
+Adding a comment to an existing issue does not help speed up the development in any way.
 
 ###Importing ROMs
 [See the instructions on the wiki](https://github.com/jasarien/Provenance/wiki/Importing-ROMs)
@@ -63,19 +70,19 @@ Feel free to suggest/request features using the Issues page, but please read all
 
 Sega system emulation is provided by [Genesis Plus GX](http://code.google.com/p/genplus-gx/), originally written by Charles Mac Donald, and later improved by Eke-Eke.
 
-NES Emulation is provided by [FCEUX](http://www.fceux.com/web/home.html).
+NES/Famicom Disk System emulation is provided by [FCEUX](http://www.fceux.com/web/home.html).
 
-SNES emulation is provided by [SNES9x](http://www.snes9x.com).
+SNES (Super Nintendo) emulation is provided by [SNES9x](http://www.snes9x.com).
 
 Gameboy Advance emulation is provided by [Visualboy Advance](http://sourceforge.net/projects/vba/).
 
 Gameboy/Gameboy Color emulation is provided by [Gambatte](http://gambatte.sourceforge.net/).
 
-The specific implementations used in Provenance are based on [OpenEmu](http://openemu.org), [(source)](http://github.com/OpenEmu).
+The specific implementations used in Provenance are loosely based on some of the work done by [OpenEmu](http://openemu.org) [(source)](http://github.com/OpenEmu) and [RetroArch](http://www.libretro.com) [(source)](https://github.com/libretro/RetroArch).
 
 #Provenance License
 
-Copyright (c) 2015, James Addyman (JamSoft). All rights reserved.
+Copyright (c) 2016, James Addyman (JamSoft). All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are
 permitted provided that the following conditions are met:
@@ -100,7 +107,7 @@ or implied, of James Addyman (JamSoft).
 
 #OpenEmu License
 
-Copyright (c) 2015, OpenEmu Team
+Copyright (c) 2016, OpenEmu Team
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Fixed the copyright dates and made a few other changes to README.mdown to make things a little more clear in an effort to hopefully prevent comments on Issues regarding new cores and other things.