### PR TITLE
Adjustments to control layout

### DIFF
--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -119,13 +119,18 @@
         {
             NSString *controlType = [control objectForKey:PVControlTypeKey];
             
+            BOOL compactVertical = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
+            CGFloat kDPadTopMargin = 16.0f;
+            CGFloat controlOriginY = compactVertical ? kDPadTopMargin : CGRectGetWidth(self.view.frame) + kDPadTopMargin;
+			
             if ([controlType isEqualToString:PVDPad])
             {
                 CGFloat xPadding = 5;
-                CGFloat yPadding = 5;
+                CGFloat bottomPadding = 16;
                 CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
-                CGRect dPadFrame = CGRectMake(xPadding, [[self view] bounds].size.height - size.height - yPadding, size.width, size.height);
-
+                CGFloat dPadOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - size.height - bottomPadding);
+                CGRect dPadFrame = CGRectMake(xPadding, dPadOriginY, size.width, size.height);
+                
                 if (!self.dPad)
                 {
                     self.dPad = [[JSDPad alloc] initWithFrame:dPadFrame];
@@ -142,9 +147,11 @@
             else if ([controlType isEqualToString:PVButtonGroup])
             {
                 CGFloat xPadding = 5;
-                CGFloat yPadding = 5;
+                CGFloat bottomPadding = 32;
                 CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
-                CGRect buttonsFrame = CGRectMake([[self view] bounds].size.width - size.width - xPadding, [[self view] bounds].size.height - size.height - yPadding, size.width, size.height);
+				
+                CGFloat buttonsOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - size.height - bottomPadding);
+                CGRect buttonsFrame = CGRectMake(CGRectGetMaxX(self.view.bounds) - size.width - xPadding, buttonsOriginY, size.width, size.height);
 
                 if (!self.buttonGroup)
                 {

--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -21,7 +21,6 @@
 @interface PVControllerViewController ()
 
 @property (nonatomic, strong) NSArray *controlLayout;
-@property (nonatomic, assign) BOOL touchControlsSetup;
 
 @end
 
@@ -33,7 +32,6 @@
 	{
 		self.controlLayout = controlLayout;
         self.systemIdentifier = systemIdentifier;
-        self.touchControlsSetup = NO;
 	}
 	
 	return self;
@@ -110,173 +108,169 @@
 - (void)setupTouchControls
 {
 #if !TARGET_OS_TV
-    if (!self.touchControlsSetup)
-    {
-        self.touchControlsSetup = YES;
-        CGFloat alpha = [[PVSettingsModel sharedInstance] controllerOpacity];
-        
-        for (NSDictionary *control in self.controlLayout)
-        {
-            NSString *controlType = [control objectForKey:PVControlTypeKey];
-            
-            BOOL compactVertical = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
-            CGFloat kDPadTopMargin = 16.0f;
-            CGFloat controlOriginY = compactVertical ? kDPadTopMargin : CGRectGetWidth(self.view.frame) + kDPadTopMargin;
+	CGFloat alpha = [[PVSettingsModel sharedInstance] controllerOpacity];
+	
+	for (NSDictionary *control in self.controlLayout)
+	{
+		NSString *controlType = [control objectForKey:PVControlTypeKey];
+		
+		BOOL compactVertical = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
+		CGFloat kDPadTopMargin = 32.0;
+		CGFloat controlOriginY = compactVertical ? kDPadTopMargin : CGRectGetWidth(self.view.frame) + kDPadTopMargin;
+		
+		if ([controlType isEqualToString:PVDPad])
+		{
+			CGFloat xPadding = 5;
+			CGFloat bottomPadding = 16;
+			CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
+			CGFloat dPadOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - size.height - bottomPadding);
+			CGRect dPadFrame = CGRectMake(xPadding, dPadOriginY, size.width, size.height);
 			
-            if ([controlType isEqualToString:PVDPad])
-            {
-                CGFloat xPadding = 5;
-                CGFloat bottomPadding = 16;
-                CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
-                CGFloat dPadOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - size.height - bottomPadding);
-                CGRect dPadFrame = CGRectMake(xPadding, dPadOriginY, size.width, size.height);
-                
-                if (!self.dPad)
-                {
-                    self.dPad = [[JSDPad alloc] initWithFrame:dPadFrame];
-                    [self.dPad setDelegate:self];
-                    [self.dPad setAlpha:alpha];
-                    [self.dPad setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin];
-                    [self.view addSubview:self.dPad];
-                }
-                else
-                {
-                    [self.dPad setFrame:dPadFrame];
-                }
-            }
-            else if ([controlType isEqualToString:PVButtonGroup])
-            {
-                CGFloat xPadding = 5;
-                CGFloat bottomPadding = 32;
-                CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
+			if (!self.dPad)
+			{
+				self.dPad = [[JSDPad alloc] initWithFrame:dPadFrame];
+				[self.dPad setDelegate:self];
+				[self.dPad setAlpha:alpha];
+				[self.dPad setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin];
+				[self.view addSubview:self.dPad];
+			}
+			else
+			{
+				[self.dPad setFrame:dPadFrame];
+			}
+		}
+		else if ([controlType isEqualToString:PVButtonGroup])
+		{
+			CGFloat xPadding = 5;
+			CGFloat bottomPadding = 32;
+			CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
+			
+			CGFloat buttonsOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - size.height - bottomPadding);
+			CGRect buttonsFrame = CGRectMake(CGRectGetMaxX(self.view.bounds) - size.width - xPadding, buttonsOriginY, size.width, size.height);
+			
+			if (!self.buttonGroup)
+			{
+				self.buttonGroup = [[UIView alloc] initWithFrame:buttonsFrame];
+				[self.buttonGroup setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin];
 				
-                CGFloat buttonsOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - size.height - bottomPadding);
-                CGRect buttonsFrame = CGRectMake(CGRectGetMaxX(self.view.bounds) - size.width - xPadding, buttonsOriginY, size.width, size.height);
-
-                if (!self.buttonGroup)
-                {
-                    self.buttonGroup = [[UIView alloc] initWithFrame:buttonsFrame];
-                    [self.buttonGroup setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin];
-                    
-                    NSArray *groupedButtons = [control objectForKey:PVGroupedButtonsKey];
-                    for (NSDictionary *groupedButton in groupedButtons)
-                    {
-                        CGRect buttonFrame = CGRectFromString([groupedButton objectForKey:PVControlFrameKey]);
-                        JSButton *button = [[JSButton alloc] initWithFrame:buttonFrame];
-                        [[button titleLabel] setText:[groupedButton objectForKey:PVControlTitleKey]];
-                        [button setBackgroundImage:[UIImage imageNamed:@"button"]];
-                        [button setBackgroundImagePressed:[UIImage imageNamed:@"button-pressed"]];
-                        [button setDelegate:self];
-                        [self.buttonGroup addSubview:button];
-                    }
-                    
-                    PVButtonGroupOverlayView *buttonOverlay = [[PVButtonGroupOverlayView alloc] initWithButtons:[self.buttonGroup subviews]];
-                    [buttonOverlay setSize:[self.buttonGroup bounds].size];
-                    [self.buttonGroup addSubview:buttonOverlay];
-                    [self.buttonGroup setAlpha:alpha];
-                    [self.view addSubview:self.buttonGroup];
-                }
-                else
-                {
-                    [self.buttonGroup setFrame:buttonsFrame];
-                }
-            }
-            else if ([controlType isEqualToString:PVLeftShoulderButton])
-            {
-                CGFloat xPadding = 10;
-                CGFloat yPadding = 10;
-                CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
-                CGRect leftShoulderFrame = CGRectMake(xPadding, yPadding, size.width, size.height);
-                
-                if (!self.leftShoulderButton)
-                {
-                    self.leftShoulderButton = [[JSButton alloc] initWithFrame:leftShoulderFrame];
-                    [[self.leftShoulderButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
-                    [self.leftShoulderButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
-                    [self.leftShoulderButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
-                    [self.leftShoulderButton setDelegate:self];
-                    [self.leftShoulderButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
-                    [self.leftShoulderButton setAlpha:alpha];
-                    [self.leftShoulderButton setAutoresizingMask:UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin];
-                    [self.view addSubview:self.leftShoulderButton];
-                }
-                else
-                {
-                    [self.leftShoulderButton setFrame:leftShoulderFrame];
-                }
-            }
-            else if ([controlType isEqualToString:PVRightShoulderButton])
-            {
-                CGFloat xPadding = 10;
-                CGFloat yPadding = 10;
-                CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
-                CGRect rightShoulderFrame = CGRectMake(self.view.frame.size.width - size.width - xPadding, yPadding, size.width, size.height);
-                
-                if (!self.rightShoulderButton)
-                {
-                    self.rightShoulderButton = [[JSButton alloc] initWithFrame:rightShoulderFrame];
-                    [[self.rightShoulderButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
-                    [self.rightShoulderButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
-                    [self.rightShoulderButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
-                    [self.rightShoulderButton setDelegate:self];
-                    [self.rightShoulderButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
-                    [self.rightShoulderButton setAlpha:alpha];
-                    [self.rightShoulderButton setAutoresizingMask:UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin];
-                    [self.view addSubview:self.rightShoulderButton];
-                }
-                else
-                {
-                    [self.rightShoulderButton setFrame:rightShoulderFrame];
-                }
-            }
-            else if ([controlType isEqualToString:PVStartButton])
-            {
-                CGFloat yPadding = 10;
-                CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
-                CGRect startFrame = CGRectMake((self.view.frame.size.width - size.width) / 2, self.view.frame.size.height - size.height - yPadding, size.width, size.height);
-                
-                if (!self.startButton)
-                {
-                    self.startButton = [[JSButton alloc] initWithFrame:startFrame];
-                    [[self.startButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
-                    [self.startButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
-                    [self.startButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
-                    [self.startButton setDelegate:self];
-                    [self.startButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
-                    [self.startButton setAlpha:alpha];
-                    [self.startButton setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin];
-                    [self.view addSubview:self.startButton];
-                }
-                else
-                {
-                    [self.startButton setFrame:startFrame];
-                }
-            }
-            else if ([controlType isEqualToString:PVSelectButton])
-            {
-                CGFloat yPadding = 10;
-                CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
-                CGRect selectFrame = CGRectMake((self.view.frame.size.width - size.width) / 2, self.view.frame.size.height - (size.height * 2) - (yPadding * 2), size.width, size.height);
-                
-                if (!self.selectButton)
-                {
-                    self.selectButton = [[JSButton alloc] initWithFrame:selectFrame];
-                    [[self.selectButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
-                    [self.selectButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
-                    [self.selectButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
-                    [self.selectButton setDelegate:self];
-                    [self.selectButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
-                    [self.selectButton setAlpha:alpha];
-                    [self.selectButton setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin];
-                    [self.view addSubview:self.selectButton];
-                }
-                else
-                {
-                    [self.selectButton setFrame:selectFrame];
-                }
-            }
-        }
-    }
+				NSArray *groupedButtons = [control objectForKey:PVGroupedButtonsKey];
+				for (NSDictionary *groupedButton in groupedButtons)
+				{
+					CGRect buttonFrame = CGRectFromString([groupedButton objectForKey:PVControlFrameKey]);
+					JSButton *button = [[JSButton alloc] initWithFrame:buttonFrame];
+					[[button titleLabel] setText:[groupedButton objectForKey:PVControlTitleKey]];
+					[button setBackgroundImage:[UIImage imageNamed:@"button"]];
+					[button setBackgroundImagePressed:[UIImage imageNamed:@"button-pressed"]];
+					[button setDelegate:self];
+					[self.buttonGroup addSubview:button];
+				}
+				
+				PVButtonGroupOverlayView *buttonOverlay = [[PVButtonGroupOverlayView alloc] initWithButtons:[self.buttonGroup subviews]];
+				[buttonOverlay setSize:[self.buttonGroup bounds].size];
+				[self.buttonGroup addSubview:buttonOverlay];
+				[self.buttonGroup setAlpha:alpha];
+				[self.view addSubview:self.buttonGroup];
+			}
+			else
+			{
+				[self.buttonGroup setFrame:buttonsFrame];
+			}
+		}
+		else if ([controlType isEqualToString:PVLeftShoulderButton])
+		{
+			CGFloat xPadding = 10;
+			CGFloat yPadding = 10;
+			CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
+			CGRect leftShoulderFrame = CGRectMake(xPadding, yPadding, size.width, size.height);
+			
+			if (!self.leftShoulderButton)
+			{
+				self.leftShoulderButton = [[JSButton alloc] initWithFrame:leftShoulderFrame];
+				[[self.leftShoulderButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
+				[self.leftShoulderButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
+				[self.leftShoulderButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
+				[self.leftShoulderButton setDelegate:self];
+				[self.leftShoulderButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
+				[self.leftShoulderButton setAlpha:alpha];
+				[self.leftShoulderButton setAutoresizingMask:UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin];
+				[self.view addSubview:self.leftShoulderButton];
+			}
+			else
+			{
+				[self.leftShoulderButton setFrame:leftShoulderFrame];
+			}
+		}
+		else if ([controlType isEqualToString:PVRightShoulderButton])
+		{
+			CGFloat xPadding = 10;
+			CGFloat yPadding = 10;
+			CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
+			CGRect rightShoulderFrame = CGRectMake(self.view.frame.size.width - size.width - xPadding, yPadding, size.width, size.height);
+			
+			if (!self.rightShoulderButton)
+			{
+				self.rightShoulderButton = [[JSButton alloc] initWithFrame:rightShoulderFrame];
+				[[self.rightShoulderButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
+				[self.rightShoulderButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
+				[self.rightShoulderButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
+				[self.rightShoulderButton setDelegate:self];
+				[self.rightShoulderButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
+				[self.rightShoulderButton setAlpha:alpha];
+				[self.rightShoulderButton setAutoresizingMask:UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin];
+				[self.view addSubview:self.rightShoulderButton];
+			}
+			else
+			{
+				[self.rightShoulderButton setFrame:rightShoulderFrame];
+			}
+		}
+		else if ([controlType isEqualToString:PVStartButton])
+		{
+			CGFloat yPadding = 10;
+			CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
+			CGRect startFrame = CGRectMake((self.view.frame.size.width - size.width) / 2, self.view.frame.size.height - size.height - yPadding, size.width, size.height);
+			
+			if (!self.startButton)
+			{
+				self.startButton = [[JSButton alloc] initWithFrame:startFrame];
+				[[self.startButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
+				[self.startButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
+				[self.startButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
+				[self.startButton setDelegate:self];
+				[self.startButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
+				[self.startButton setAlpha:alpha];
+				[self.startButton setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin];
+				[self.view addSubview:self.startButton];
+			}
+			else
+			{
+				[self.startButton setFrame:startFrame];
+			}
+		}
+		else if ([controlType isEqualToString:PVSelectButton])
+		{
+			CGFloat yPadding = 10;
+			CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
+			CGRect selectFrame = CGRectMake((self.view.frame.size.width - size.width) / 2, self.view.frame.size.height - (size.height * 2) - (yPadding * 2), size.width, size.height);
+			
+			if (!self.selectButton)
+			{
+				self.selectButton = [[JSButton alloc] initWithFrame:selectFrame];
+				[[self.selectButton titleLabel] setText:[control objectForKey:PVControlTitleKey]];
+				[self.selectButton setBackgroundImage:[UIImage imageNamed:@"button-thin"]];
+				[self.selectButton setBackgroundImagePressed:[UIImage imageNamed:@"button-thin-pressed"]];
+				[self.selectButton setDelegate:self];
+				[self.selectButton setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 4, 0)];
+				[self.selectButton setAlpha:alpha];
+				[self.selectButton setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin];
+				[self.view addSubview:self.selectButton];
+			}
+			else
+			{
+				[self.selectButton setFrame:selectFrame];
+			}
+		}
+	}
 #endif
 }
 

--- a/Provenance/Emulator/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController.m
@@ -114,7 +114,7 @@
         CGPoint origin = CGPointMake(roundf((parentSize.width - width) / 2.0), 0);
         if (([self.traitCollection userInterfaceIdiom] == UIUserInterfaceIdiomPhone) && (parentSize.height > parentSize.width))
         {
-            origin.y = roundf((parentSize.height - height) / 3.0); // top 3rd of screen
+            origin.y = 40.0f; // directly below menu button at top of screen
         }
         else
         {


### PR DESCRIPTION
## What this does
Makes minor adjustments to how elements are laid out on screen, making it more comfortable to play in portrait orientation.

![group2](https://cloud.githubusercontent.com/assets/983669/13589360/52b2e9f4-e4a5-11e5-8b22-a4fa98c20130.png)

![group](https://cloud.githubusercontent.com/assets/983669/13589108/559a98e4-e4a3-11e5-83cc-7939647149f5.png)
iPad, iPhone 6+, and iPhone 4s in portrait and landscape
