### PR TITLE
Fix buffer clearance issue causing slowdown

### DIFF
--- a/Provenance/Controller/iCade/iCadeReaderView.m
+++ b/Provenance/Controller/iCade/iCadeReaderView.m
@@ -125,7 +125,7 @@ static const char *OFF_STATES = "eczqtrfnmpgv";
     }
     
     static int cycleResponder = 0;
-    if (++cycleResponder > 20) {
+    if (++cycleResponder > 100) {
         // necessary to clear a buffer that accumulates internally
         cycleResponder = 0;
         [self resignFirstResponder];


### PR DESCRIPTION
Buffer clearing before complete emulator cycle. This caused the emulator to stutter when multiple rapid gamepad inputs were given. Making the buffer larger prevents it constantly clearing.