### PR TITLE
Increase buffer size to fix controller issue

### DIFF
--- a/Provenance/Controller/iCade/iCadeReaderView.m
+++ b/Provenance/Controller/iCade/iCadeReaderView.m
@@ -125,7 +125,7 @@ static const char *OFF_STATES = "eczqtrfnmpgv";
     }
     
     static int cycleResponder = 0;
-    if (++cycleResponder > 20) {
+    if (++cycleResponder > 100) {
         // necessary to clear a buffer that accumulates internally
         cycleResponder = 0;
         [self resignFirstResponder];


### PR DESCRIPTION
Fix for issue where emulator stalls on hitting buttons quickly. Buffer size increased to prevent it clearing too often when buttons are pressed very quickly.