### PR TITLE
Fix unavailable tvOS API build error

### DIFF
--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -1007,6 +1007,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 }
 #endif
 
+#if !TARGET_OS_TV
 - (void)doneRenaming:(id)sender
 {
     NSString *newTitle = [self.renameTextField text];
@@ -1039,8 +1040,10 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];
+
     [self.renameTextField resignFirstResponder];
 }
+#endif
 
 - (void)deleteGame:(PVGame *)game
 {
@@ -1458,6 +1461,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 
 #pragma mark - Text Field and Keyboard Delegate
 
+#if !TARGET_OS_TV
 - (BOOL)textFieldShouldReturn:(UITextField *)textField
 {
     if (textField != self.searchField)
@@ -1483,6 +1487,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
     
     return YES;
 }
+#endif
 
 - (void)handleTextFieldDidChange:(NSNotification *)notification
 {
@@ -1496,9 +1501,9 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
     }
 }
 
+#if !TARGET_OS_TV
 - (void)keyboardWillShow:(NSNotification *)note
 {
-#if !TARGET_OS_TV
 	NSDictionary *userInfo = [note userInfo];
 	
 	CGRect keyboardEndFrame = [[userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
@@ -1514,13 +1519,12 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 					 }
 					 completion:^(BOOL finished) {
 					 }];
-#endif
 }
+#endif
 
-
+#if !TARGET_OS_TV
 - (void)keyboardWillHide:(NSNotification *)note
 {
-#if !TARGET_OS_TV
 	NSDictionary *userInfo = [note userInfo];
 	
 	CGFloat animationDuration = [[userInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
@@ -1544,8 +1548,8 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 	[[NSNotificationCenter defaultCenter] removeObserver:self
 													name:UIKeyboardWillHideNotification
 												  object:nil];
-#endif
 }
+#endif
 
 #pragma mark - Image Picker Deleate
 


### PR DESCRIPTION
Fixes #290. Fix for issue where UIKeyboardWillHideNotification is unavailable when a tvOS target is built. Target checks added to keyboard notification actions and renameTextField delegate methods (not currently utilised in tvOS app).