### PR TITLE
Added support for Gameboy 128k save files

### DIFF
--- a/PVGB/GB/libgambatte/src/mem/cartridge.cpp
+++ b/PVGB/GB/libgambatte/src/mem/cartridge.cpp
@@ -609,7 +609,28 @@ LoadRes Cartridge::loadROM(std::string const &romfile,
 		default: return -1;
 		}*/
 
-		rambanks = numRambanksFromH14x(header[0x147], header[0x149]);
+		//rambanks = numRambanksFromH14x(header[0x147], header[0x149]);
+        
+        switch (header[0x0149]) {
+            case 0x00: /*std::puts("No RAM");*/ rambanks = type == type_mbc2; break;
+            case 0x01: /*std::puts("2kB RAM");*/ /*rambankrom=1; break;*/
+            case 0x02: /*std::puts("8kB RAM");*/
+                rambanks = 1;
+                break;
+            case 0x03: /*std::puts("32kB RAM");*/
+                rambanks = 4;
+                break;
+            case 0x04: /*std::puts("128kB RAM");*/
+                rambanks = 16;
+                break;
+            case 0x05: /*std::puts("undocumented kB RAM");*/
+                rambanks = 16;
+                break;
+            default: /*std::puts("Wrong data-format, corrupt or unsupported ROM loaded.");*/
+                rambanks = 16;
+                break;
+        }
+        
 		cgb = header[0x0143] >> 7 & (1 ^ forceDmg);
 	}
 


### PR DESCRIPTION
Some Gameboy games such as Pokemon and Little Sound DJ (http://www.littlesounddj.com/) require 128k flash save files. Provenance only supports 32k currently.

Libgambatte core has already been updated to support 128k saves but a lot of emulators (not just Provenance) have not yet updated the libraries with these changes.

I have added the changes needed; tested with LSDJ and it works great.