### PR TITLE
Use default animation when focusing in the game library

### DIFF
--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		1ADDA5B417B30CD7008A7ADD /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ADDA5B317B30CD7008A7ADD /* GLKit.framework */; };
 		1AECF4A91966D76100F8704E /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AECF4A81966D76100F8704E /* libsqlite3.dylib */; };
 		1AECF4AC1966D7A600F8704E /* OESQLiteDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AECF4AB1966D7A600F8704E /* OESQLiteDatabase.m */; };
+		25A64E171CB1C41100EDD19D /* UIImage+Color.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A64E161CB1C41100EDD19D /* UIImage+Color.m */; };
+		25A64E181CB1C57900EDD19D /* UIImage+Color.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A64E161CB1C41100EDD19D /* UIImage+Color.m */; };
 		377152D61B61D77300BAE15B /* openvgdb.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 1AECF4A61966D6D600F8704E /* openvgdb.sqlite */; };
 		378F4A001B63D7CD0065FA39 /* GCDWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 378F49DF1B63D7CD0065FA39 /* GCDWebServer.m */; };
 		378F4A011B63D7CD0065FA39 /* GCDWebServerConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 378F49E11B63D7CD0065FA39 /* GCDWebServerConnection.m */; };
@@ -452,6 +454,8 @@
 		1AECF4A81966D76100F8704E /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
 		1AECF4AA1966D7A600F8704E /* OESQLiteDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OESQLiteDatabase.h; sourceTree = "<group>"; };
 		1AECF4AB1966D7A600F8704E /* OESQLiteDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OESQLiteDatabase.m; sourceTree = "<group>"; };
+		25A64E151CB1C41100EDD19D /* UIImage+Color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Color.h"; sourceTree = "<group>"; };
+		25A64E161CB1C41100EDD19D /* UIImage+Color.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Color.m"; sourceTree = "<group>"; };
 		378F49DE1B63D7CD0065FA39 /* GCDWebServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDWebServer.h; sourceTree = "<group>"; };
 		378F49DF1B63D7CD0065FA39 /* GCDWebServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDWebServer.m; sourceTree = "<group>"; };
 		378F49E01B63D7CD0065FA39 /* GCDWebServerConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDWebServerConnection.h; sourceTree = "<group>"; };
@@ -952,6 +956,8 @@
 				1AB183611AD9BF8000E094F6 /* NSFileManager+Hashing.m */,
 				423BB97D17DD46BC0048F457 /* NSData+Hashing.h */,
 				423BB97E17DD46BC0048F457 /* NSData+Hashing.m */,
+				25A64E151CB1C41100EDD19D /* UIImage+Color.h */,
+				25A64E161CB1C41100EDD19D /* UIImage+Color.m */,
 				42E63F0417DE78AB005802B0 /* UIImage+Scaling.h */,
 				42E63F0517DE78AB005802B0 /* UIImage+Scaling.m */,
 				1A65D1C419917D55004E1777 /* UIImage+ImageEffects.h */,
@@ -1376,6 +1382,7 @@
 				1A9938A21BBB02590050A2B7 /* PVRecentGame.m in Sources */,
 				1AB95FFD17C563C200D3E392 /* PVSettingsViewController.m in Sources */,
 				1AB9600317C572B400D3E392 /* PVSettingsModel.m in Sources */,
+				25A64E171CB1C41100EDD19D /* UIImage+Color.m in Sources */,
 				1A48697417C8C0DE0019F6D2 /* PVDirectoryWatcher.m in Sources */,
 				1A26EE361AD9FFBF004EA30B /* zip.c in Sources */,
 				378F4A041B63D7CD0065FA39 /* GCDWebServerResponse.m in Sources */,
@@ -1470,6 +1477,7 @@
 				BEC075CD1C221F3A00305027 /* RLMRealmConfiguration+GroupConfig.m in Sources */,
 				1AD481D51BA3542A00FDA50A /* GCDWebUploader.m in Sources */,
 				BE1E26681C2252CA00499BA0 /* PVEmulatorConstants.m in Sources */,
+				25A64E181CB1C57900EDD19D /* UIImage+Color.m in Sources */,
 				1AD481F61BA3549F00FDA50A /* UIImage+ImageEffects.m in Sources */,
 				1AD481FA1BA354B100FDA50A /* PViCadeGamepad.m in Sources */,
 				1AD481DD1BA3544800FDA50A /* GCDWebServerFileRequest.m in Sources */,

--- a/Provenance/Categories/UIImage+Color.h
+++ b/Provenance/Categories/UIImage+Color.h
@@ -1,0 +1,15 @@
+//
+//  UIImage+Color.h
+//  Provenance
+//
+//  Created by Tyler Hedrick on 4/3/16.
+//  Copyright © 2016 James Addyman. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (Color)
++ (UIImage *)imageWithSize:(CGSize)size
+                     color:(UIColor *)color
+                      text:(NSAttributedString *)text;
+@end

--- a/Provenance/Categories/UIImage+Color.m
+++ b/Provenance/Categories/UIImage+Color.m
@@ -1,0 +1,38 @@
+//
+//  UIImage+Color.m
+//  Provenance
+//
+//  Created by Tyler Hedrick on 4/3/16.
+//  Copyright © 2016 James Addyman. All rights reserved.
+//
+
+#import "UIImage+Color.h"
+
+@implementation UIImage (Color)
+
++ (UIImage *)imageWithSize:(CGSize)size
+                     color:(UIColor *)color
+                      text:(NSAttributedString *)text {
+    CGRect rect = CGRectMake(0, 0, size.width, size.height);
+    UIGraphicsBeginImageContextWithOptions(rect.size, NO, [UIScreen mainScreen].scale);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextSetFillColorWithColor(context, [color CGColor]);
+    CGContextSetStrokeColorWithColor(context, [[UIColor colorWithWhite:0.7 alpha:0.6] CGColor]);
+    CGContextSetLineWidth(context, 0.5);
+    CGContextFillRect(context, rect);
+    
+    CGRect boundingRect = [text boundingRectWithSize:rect.size
+                                             options:NSStringDrawingUsesFontLeading | NSStringDrawingUsesLineFragmentOrigin
+                                             context:NULL];
+    boundingRect.origin = CGPointMake(CGRectGetMidX(rect) - (CGRectGetWidth(boundingRect) / 2),
+                                      CGRectGetMidY(rect) - (CGRectGetHeight(boundingRect) / 2));
+    [text drawInRect:boundingRect];
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return image;
+}
+
+@end

--- a/Provenance/Game Library/PVGameLibraryCollectionViewCell.h
+++ b/Provenance/Game Library/PVGameLibraryCollectionViewCell.h
@@ -14,4 +14,6 @@
 @property (nonatomic, readonly) UILabel *titleLabel;
 @property (nonatomic, readonly) UILabel *missingLabel;
 
+- (void)setText:(NSString *)text;
+
 @end

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -1350,7 +1350,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         }
     });
     
-	[[cell titleLabel] setText:[game title]];
+	[cell setText:[game title]];
 	[[cell missingLabel] setText:[game title]];
 	
     [cell setNeedsLayout];
@@ -1400,7 +1400,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 - (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout insetForSectionAtIndex:(NSInteger)section
 {
 #if TARGET_OS_TV
-    	return UIEdgeInsetsMake(40, 40, 40, 40);
+    	return UIEdgeInsetsMake(40, 40, 120, 40);
 #else
     	return UIEdgeInsetsMake(5, 5, 5, 5);
 #endif


### PR DESCRIPTION
This changes the game library cell to use the built-in focus engine / animation. I added a category on UIImage to generate an image with a color and text so focus would apply to games without artwork as well. I also wanted to replicate the same logic that the tvOS home screen uses for the titles, so they don't display by default, and instead animate it when that item comes into focus.

This is just a proposal, the code is a little messy and I'm happy to clean it up if this is something you're interested in doing with the project. Here are screenshots of tvOS and iOS versions

![simulator screen shot apr 3 2016 7 44 28 pm](https://cloud.githubusercontent.com/assets/796488/14237204/7efbaf92-f9d5-11e5-8f9a-579cf4a77c9f.png)

![simulator screen shot apr 3 2016 7 52 03 pm](https://cloud.githubusercontent.com/assets/796488/14237207/8df68a26-f9d5-11e5-9434-13a8e82dde12.png)

