### PR TITLE
Fix #246: Add Order By to Like Query to get a more favorable rom match

### DIFF
--- a/Provenance/Game Library/PVGameImporter.m
+++ b/Provenance/Game Library/PVGameImporter.m
@@ -566,14 +566,14 @@
     
     NSArray *results = nil;
     NSString *exactQuery = @"SELECT DISTINCT releaseTitleName as 'gameTitle', releaseCoverFront as 'boxImageURL' FROM ROMs rom LEFT JOIN RELEASES release USING (romID) WHERE %@ = '%@'";
-    NSString *likeQuery = @"SELECT DISTINCT romFileName, releaseTitleName as 'gameTitle', releaseCoverFront as 'boxImageURL', regionName as 'region', systemShortName FROM ROMs rom LEFT JOIN RELEASES release USING (romID) LEFT JOIN SYSTEMS system USING (systemID) LEFT JOIN REGIONS region on (regionLocalizedID=region.regionID) WHERE %@ LIKE \"%%%@%%\" AND systemID=\"%@\"";
+    NSString *likeQuery = @"SELECT DISTINCT romFileName, releaseTitleName as 'gameTitle', releaseCoverFront as 'boxImageURL', regionName as 'region', systemShortName FROM ROMs rom LEFT JOIN RELEASES release USING (romID) LEFT JOIN SYSTEMS system USING (systemID) LEFT JOIN REGIONS region on (regionLocalizedID=region.regionID) WHERE %@ LIKE \"%%%@%%\" AND systemID=\"%@\" ORDER BY case when %@ LIKE \"%@%%\" then 1 else 0 end DESC";
     NSString *queryString = nil;
     
     NSString *dbSystemID = [[PVEmulatorConfiguration sharedInstance] databaseIDForSystemID:systemID];
     
     if ([key isEqualToString:@"romFileName"])
     {
-        queryString = [NSString stringWithFormat:likeQuery, key, value, dbSystemID];
+        queryString = [NSString stringWithFormat:likeQuery, key, value, dbSystemID, key, value];
     }
     else
     {


### PR DESCRIPTION
Fixes many cases of #246 by adding an Order by to the SQLite 'likeQuery'.  The order by sorts the results into an order that favors matches that begin with the same string as the passed in 'romFileName' key.

With the example given in #246 of 'Super Mario World', the first 3 results are now as follows:
```
{
    boxImageURL = "http://img.gamefaqs.net/box/6/2/6/14626_front.jpg";
    gameTitle = "Super Mario World";
    region = Europe;
    romFileName = "Super Mario World (Europe) (Rev 1).sfc";
    systemShortName = SNES;
},
{
    boxImageURL = "http://img.gamefaqs.net/box/6/2/6/14626_front.jpg";
    gameTitle = "Super Mario World";
    region = Europe;
    romFileName = "Super Mario World (Europe).sfc";
    systemShortName = SNES;
},
{
    boxImageURL = "http://img.gamefaqs.net/box/6/2/5/14625_front.jpg";
    gameTitle = "Super Mario World";
    region = USA;
    romFileName = "Super Mario World (USA).sfc";
    systemShortName = SNES;
}
```
The Super Mario All-Star results have been sorted down, and will not be the first result chosen.
This test was done with a hacked version of Super Mario World, that could not match on md5 hash.