### PR TITLE
Always prefer a gamepad over the Siri Remote

### DIFF
--- a/Provenance/Controller/PVControllerManager.h
+++ b/Provenance/Controller/PVControllerManager.h
@@ -11,6 +11,8 @@
 
 @class PViCadeController;
 
+extern NSString * const PVControllerManagerControllerReassignedNotification;
+
 @interface PVControllerManager : NSObject
 
 + (PVControllerManager *)sharedManager;

--- a/Provenance/Controller/PVControllerSelectionViewController.m
+++ b/Provenance/Controller/PVControllerSelectionViewController.m
@@ -15,6 +15,25 @@
 
 @implementation PVControllerSelectionViewController
 
+- (void)viewWillAppear:(BOOL)animated;
+{
+    [super viewWillAppear:animated];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleControllerReassigned:)
+                                                 name:PVControllerManagerControllerReassignedNotification
+                                               object:nil];
+}
+
+- (void)viewDidDisappear:(BOOL)animated;
+{
+    [super viewDidDisappear:animated];
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:PVControllerManagerControllerReassignedNotification
+                                                  object:nil];
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -26,6 +45,11 @@
 #else
     [self setTitle:@"Controller Settings"];
 #endif
+}
+
+- (void)handleControllerReassigned:(NSNotification *)notification;
+{
+    [self.tableView reloadData];
 }
 
 #pragma mark - UITableViewDataSource


### PR DESCRIPTION
If an extended controller is connected, assign it to an empty slot or to a slot used by a micro gamepad.
Look for available controllers once a controller is disconnected.
Refresh controller selection view controller once a controller is automatically assigned.
Fix #361