### PR TITLE
Game library scrolls very smooth now.

### DIFF
--- a/Provenance/Game Library/PVGame.h
+++ b/Provenance/Game Library/PVGame.h
@@ -21,4 +21,6 @@
 @property BOOL requiresSync;
 @property NSString *systemIdentifier;
 
+- (NSString *)placeholderImageName;
+
 @end

--- a/Provenance/Game Library/PVGame.h
+++ b/Provenance/Game Library/PVGame.h
@@ -21,6 +21,4 @@
 @property BOOL requiresSync;
 @property NSString *systemIdentifier;
 
-- (NSString *)placeholderImageName;
-
 @end

--- a/Provenance/Game Library/PVGame.m
+++ b/Provenance/Game Library/PVGame.m
@@ -7,7 +7,7 @@
 //
 
 #import "PVGame.h"
-
+#import "PVEmulatorConstants.h"
 
 @implementation PVGame
 
@@ -31,6 +31,39 @@
 			 @"originalArtworkURL",
 			 @"md5Hash",
 			 @"systemIdentifier"];
+}
+
+- (NSString *)placeholderImageName {
+    
+    // TODO: to be replaced with the correct system placeholder
+    
+    NSString *systemImageName = @"UNKNONW";
+    
+    if ([self.systemIdentifier isEqualToString:PVGenesisSystemIdentifier]) {
+        return systemImageName = @"GENESIS";
+    } else if ([self.systemIdentifier isEqualToString:PVGameGearSystemIdentifier]) {
+        return systemImageName = @"GAME GEAR";
+    } else if ([self.systemIdentifier isEqualToString:PVMasterSystemSystemIdentifier]) {
+        return systemImageName = @"MASTER SYSTEM";
+    } else if ([self.systemIdentifier isEqualToString:PVSegaCDSystemIdentifier]) {
+        return systemImageName = @"SEGA CD";
+    } else if ([self.systemIdentifier isEqualToString:PVSG1000SystemIdentifier]) {
+        return systemImageName = @"SG 1000";
+    } else if ([self.systemIdentifier isEqualToString:PVSNESSystemIdentifier]) {
+        return systemImageName = @"SNES";
+    } else if ([self.systemIdentifier isEqualToString:PVNESSystemIdentifier]) {
+        return systemImageName = @"NES";
+    } else if ([self.systemIdentifier isEqualToString:PVFDSSystemIdentifier]) {
+        return systemImageName = @"FAMICOM";
+    } else if ([self.systemIdentifier isEqualToString:PVGBASystemIdentifier]) {
+        return systemImageName = @"GAME BOY ADVANCE";
+    } else if ([self.systemIdentifier isEqualToString:PVGBCSystemIdentifier]) {
+        return systemImageName = @"GAME BOY COLOR";;
+    } else if ([self.systemIdentifier isEqualToString:PVGBSystemIdentifier]) {
+        return systemImageName = @"GAME BOY";;
+    }
+
+    return systemImageName;
 }
 
 @end

--- a/Provenance/Game Library/PVGame.m
+++ b/Provenance/Game Library/PVGame.m
@@ -7,7 +7,6 @@
 //
 
 #import "PVGame.h"
-#import "PVEmulatorConstants.h"
 
 @implementation PVGame
 
@@ -31,39 +30,6 @@
 			 @"originalArtworkURL",
 			 @"md5Hash",
 			 @"systemIdentifier"];
-}
-
-- (NSString *)placeholderImageName {
-    
-    // TODO: to be replaced with the correct system placeholder
-    
-    NSString *systemImageName = @"UNKNONW";
-    
-    if ([self.systemIdentifier isEqualToString:PVGenesisSystemIdentifier]) {
-        return systemImageName = @"GENESIS";
-    } else if ([self.systemIdentifier isEqualToString:PVGameGearSystemIdentifier]) {
-        return systemImageName = @"GAME GEAR";
-    } else if ([self.systemIdentifier isEqualToString:PVMasterSystemSystemIdentifier]) {
-        return systemImageName = @"MASTER SYSTEM";
-    } else if ([self.systemIdentifier isEqualToString:PVSegaCDSystemIdentifier]) {
-        return systemImageName = @"SEGA CD";
-    } else if ([self.systemIdentifier isEqualToString:PVSG1000SystemIdentifier]) {
-        return systemImageName = @"SG 1000";
-    } else if ([self.systemIdentifier isEqualToString:PVSNESSystemIdentifier]) {
-        return systemImageName = @"SNES";
-    } else if ([self.systemIdentifier isEqualToString:PVNESSystemIdentifier]) {
-        return systemImageName = @"NES";
-    } else if ([self.systemIdentifier isEqualToString:PVFDSSystemIdentifier]) {
-        return systemImageName = @"FAMICOM";
-    } else if ([self.systemIdentifier isEqualToString:PVGBASystemIdentifier]) {
-        return systemImageName = @"GAME BOY ADVANCE";
-    } else if ([self.systemIdentifier isEqualToString:PVGBCSystemIdentifier]) {
-        return systemImageName = @"GAME BOY COLOR";;
-    } else if ([self.systemIdentifier isEqualToString:PVGBSystemIdentifier]) {
-        return systemImageName = @"GAME BOY";;
-    }
-
-    return systemImageName;
 }
 
 @end

--- a/Provenance/Game Library/PVGameLibraryCollectionViewCell.h
+++ b/Provenance/Game Library/PVGameLibraryCollectionViewCell.h
@@ -8,12 +8,10 @@
 
 #import <UIKit/UIKit.h>
 
+@class PVGame;
+
 @interface PVGameLibraryCollectionViewCell : UICollectionViewCell
 
-@property (nonatomic, readonly) UIImageView *imageView;
-@property (nonatomic, readonly) UILabel *titleLabel;
-@property (nonatomic, readonly) UILabel *missingLabel;
-
-- (void)setText:(NSString *)text;
+- (void)setupWithGame:(PVGame *)game;
 
 @end

--- a/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
+++ b/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
@@ -14,6 +14,7 @@
 #import "PVGame.h"
 #import "PVMediaCache.h"
 #import "PVAppConstants.h"
+#import "PVEmulatorConfiguration.h"
 
 CGSize pv_CGSizeAspectFittingSize(CGSize originalSize, CGSize maximumSize) {
     CGFloat width = originalSize.width;
@@ -115,10 +116,12 @@ CGSize pv_CGSizeAspectFittingSize(CGSize originalSize, CGSize maximumSize) {
     NSString *originalArtworkURL = [game originalArtworkURL];
     
     [_titleLabel setText:[game title]];
+    
+    NSString *placeholderImageText = [[PVEmulatorConfiguration sharedInstance] shortNameForSystemIdentifier:game.systemIdentifier];
 
     if ([artworkURL isEqualToString:@""] &&
         [originalArtworkURL isEqualToString:@""]) {
-        self.imageView.image = [self imageWithText:[game placeholderImageName]];
+        self.imageView.image = [self imageWithText:placeholderImageText];
     } else {
         NSString *key = [artworkURL length] ? artworkURL : nil;
         
@@ -130,7 +133,7 @@ CGSize pv_CGSizeAspectFittingSize(CGSize originalSize, CGSize maximumSize) {
             self.operation = [[PVMediaCache shareInstance] imageForKey:key
                                                             completion:^(UIImage *image) {
                                                                 
-                                                                UIImage *artwork = image ?: [self imageWithText:[game placeholderImageName]];
+                                                                UIImage *artwork = image ?: [self imageWithText:placeholderImageText];
                                                                 
                                                                 self.imageView.image = artwork;
                                                                 [self setNeedsLayout];

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -1394,33 +1394,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         game = games[[indexPath item]];
     }
 	
-	NSString *artworkURL = [game customArtworkURL];
-	NSString *originalArtworkURL = [game originalArtworkURL];
-    __block UIImage *artwork = nil;
-
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        if ([artworkURL length])
-        {
-            artwork = [PVMediaCache imageForKey:artworkURL];
-        }
-        else if ([originalArtworkURL length])
-        {
-            artwork = [PVMediaCache imageForKey:originalArtworkURL];
-        }
-        
-        if (artwork)
-        {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[cell imageView] setImage:artwork];
-                [cell setNeedsLayout];
-            });
-        }
-    });
-    
-	[cell setText:[game title]];
-	[[cell missingLabel] setText:[game title]];
-	
-    [cell setNeedsLayout];
+    [cell setupWithGame:game];
     
 	return cell;
 }
@@ -1625,11 +1599,11 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 	[self dismissViewControllerAnimated:YES completion:NULL];
 	
 	UIImage *image = info[UIImagePickerControllerOriginalImage];
-	image = [image scaledImageWithMaxResolution:200];
+	image = [image scaledImageWithMaxResolution:PVThumbnailMaxResolution];
 	
 	if (image)
 	{
-		NSData *imageData = UIImagePNGRepresentation(image);
+		NSData *imageData = UIImageJPEGRepresentation(image, PVThumbnailQuality);
 		NSString *hash = [imageData md5Hash];
 		[PVMediaCache writeDataToDisk:imageData withKey:hash];
         [self.realm beginWriteTransaction];

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -1603,7 +1603,7 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
 	
 	if (image)
 	{
-		NSData *imageData = UIImageJPEGRepresentation(image, PVThumbnailQuality);
+        NSData *imageData = UIImagePNGRepresentation(image);
 		NSString *hash = [imageData md5Hash];
 		[PVMediaCache writeDataToDisk:imageData withKey:hash];
         [self.realm beginWriteTransaction];

--- a/Provenance/Game Library/PVMediaCache.h
+++ b/Provenance/Game Library/PVMediaCache.h
@@ -12,8 +12,10 @@ extern NSString * const PVMediaCacheWasEmptiedNotification;
     
 }
 
++ (instancetype)shareInstance;
+
 + (NSString *)cachePath;
-+ (UIImage *)imageForKey:(NSString *)key;
+- (NSBlockOperation *)imageForKey:(NSString *)key completion:(void(^)(UIImage *image))completion;
 + (NSString *)filePathForKey:(NSString *)key;
 + (NSString *)writeImageToDisk:(UIImage *)image withKey:(NSString *)key;
 + (NSString *)writeDataToDisk:(NSData *)data withKey:(NSString *)key;

--- a/Provenance/Game Library/PVMediaCache.m
+++ b/Provenance/Game Library/PVMediaCache.m
@@ -129,7 +129,7 @@ NSString * const PVMediaCacheWasEmptiedNotification = @"PVMediaCacheWasEmptiedNo
     
     UIImage *newImage = [image scaledImageWithMaxResolution:PVThumbnailMaxResolution];
     
-	NSData *imageData = UIImageJPEGRepresentation(newImage, PVThumbnailQuality);
+    NSData *imageData = UIImagePNGRepresentation(newImage);
 	
 	return [self writeDataToDisk:imageData withKey:key];
 }

--- a/Provenance/Game Library/PVMediaCache.m
+++ b/Provenance/Game Library/PVMediaCache.m
@@ -7,12 +7,41 @@
 
 #import "PVMediaCache.h"
 #import "NSString+Hashing.h"
+#import "UIImage+Scaling.h"
+#import "PVAppConstants.h"
 
 NSString * const kPVCachePath = @"PVCache";
 
 NSString * const PVMediaCacheWasEmptiedNotification = @"PVMediaCacheWasEmptiedNotification";
 
+@interface PVMediaCache ()
+
+@property (strong, nonatomic) NSOperationQueue *operationQueue;
+
+@end
+
 @implementation PVMediaCache
+
+#pragma mark - Object life cycle
+
++ (instancetype)shareInstance {
+    static dispatch_once_t onceToken;
+    static PVMediaCache *cache = nil;
+    dispatch_once(&onceToken, ^{
+        cache = [[PVMediaCache alloc] init];
+        [cache configure];
+    });
+    
+    return cache;
+}
+
+#pragma mark - Private
+
+- (void)configure {
+    self.operationQueue = [[NSOperationQueue alloc] init];
+}
+
+#pragma mark - Public
 
 + (NSString *)cachePath
 {
@@ -42,24 +71,37 @@ NSString * const PVMediaCacheWasEmptiedNotification = @"PVMediaCacheWasEmptiedNo
 	return cachePath;
 }
 
-+ (UIImage *)imageForKey:(NSString *)key
-{
+- (NSBlockOperation *)imageForKey:(NSString *)key completion:(void (^)(UIImage *))completion {
     if (![key length])
     {
+        if (completion) {
+            completion(nil);
+        }
         return nil;
     }
     
-	NSString *cachePath = [self cachePath];	
-	NSString *keyHash = [key MD5Hash];
-	cachePath = [cachePath stringByAppendingPathComponent:keyHash];
-	
-	UIImage *image = nil;
-	if ([[NSFileManager defaultManager] fileExistsAtPath:cachePath])
-	{
-		image = [UIImage imageWithContentsOfFile:cachePath];
-	}
-	
-	return image;
+    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
+        
+        NSString *cachePath = [[self class] cachePath];
+        NSString *keyHash = [key MD5Hash];
+        cachePath = [cachePath stringByAppendingPathComponent:keyHash];
+        
+        UIImage *image = nil;
+        if ([[NSFileManager defaultManager] fileExistsAtPath:cachePath])
+        {
+            image = [UIImage imageWithContentsOfFile:cachePath];
+        }
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (completion) {
+                completion(image);
+            }
+        });
+    }];
+    
+    [self.operationQueue addOperation:operation];
+    
+    return operation;
 }
 
 + (NSString *)filePathForKey:(NSString *)key
@@ -85,7 +127,9 @@ NSString * const PVMediaCacheWasEmptiedNotification = @"PVMediaCacheWasEmptiedNo
         return nil;
     }
     
-	NSData *imageData = UIImagePNGRepresentation(image);
+    UIImage *newImage = [image scaledImageWithMaxResolution:PVThumbnailMaxResolution];
+    
+	NSData *imageData = UIImageJPEGRepresentation(newImage, PVThumbnailQuality);
 	
 	return [self writeDataToDisk:imageData withKey:key];
 }

--- a/ProvenanceTV/PVAppConstants.h
+++ b/ProvenanceTV/PVAppConstants.h
@@ -21,3 +21,6 @@ extern NSString *const PVAppGroupId;
 extern NSString *const PVGameControllerKey;
 extern NSString *const PVGameMD5Key;
 extern NSString *const PVAppURLKey;
+
+extern float const PVThumbnailMaxResolution;
+extern float const PVThumbnailQuality;

--- a/ProvenanceTV/PVAppConstants.h
+++ b/ProvenanceTV/PVAppConstants.h
@@ -23,4 +23,3 @@ extern NSString *const PVGameMD5Key;
 extern NSString *const PVAppURLKey;
 
 extern float const PVThumbnailMaxResolution;
-extern float const PVThumbnailQuality;

--- a/ProvenanceTV/PVAppConstants.m
+++ b/ProvenanceTV/PVAppConstants.m
@@ -15,3 +15,11 @@ NSString *const PVAppGroupId = @"";
 NSString *const PVGameControllerKey = @"PlayController";
 NSString *const PVGameMD5Key = @"md5";
 NSString *const PVAppURLKey = @"provenance";
+
+#if TARGET_OS_TV
+    float const PVThumbnailMaxResolution = 400.0;
+#else
+    float const PVThumbnailMaxResolution = 200.0;
+#endif
+
+float const PVThumbnailQuality = 0.7;

--- a/ProvenanceTV/PVAppConstants.m
+++ b/ProvenanceTV/PVAppConstants.m
@@ -21,5 +21,3 @@ NSString *const PVAppURLKey = @"provenance";
 #else
     float const PVThumbnailMaxResolution = 200.0;
 #endif
-
-float const PVThumbnailQuality = 0.7;

--- a/ProvenanceTV/PVSearchViewController.m
+++ b/ProvenanceTV/PVSearchViewController.m
@@ -232,31 +232,8 @@
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
 	PVGameLibraryCollectionViewCell *cell = [self.collectionView dequeueReusableCellWithReuseIdentifier:@"SearchResultCell" forIndexPath:indexPath];
 	PVGame *game = [self.searchResults objectAtIndex:[indexPath item]];
-	NSString *artworkURL = [game customArtworkURL];
-	NSString *originalArtworkURL = [game originalArtworkURL];
-	__block UIImage *artwork = nil;
 
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-		if ([artworkURL length])
-		{
-			artwork = [PVMediaCache imageForKey:artworkURL];
-		}
-		else if ([originalArtworkURL length])
-		{
-			artwork = [PVMediaCache imageForKey:originalArtworkURL];
-		}
-
-		if (artwork)
-		{
-			dispatch_async(dispatch_get_main_queue(), ^{
-				[[cell imageView] setImage:artwork];
-				[cell setNeedsLayout];
-			});
-		}
-	});
-
-	[cell setText:[game title]];
-	[[cell missingLabel] setText:[game title]];
+    [cell setupWithGame:game];
 
 	[cell setNeedsLayout];
 


### PR DESCRIPTION
Hi,
I worked a little on the Game Library and now the collection view scrolls very smooth. I implemented a NSOperationQueue to download images and I set the max resolution to 200x200 for mobile devices and 400x400 for Apple TV.

I'm also preparing a set of placeholder images for the cartridge without artwork. I already modified the PVGame model to support that. What do you think about that?

Bye,
Stefano