### PR TITLE
Fix menu button not working after FDS disk swap

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.m
+++ b/Provenance/Emulator/PVEmulatorViewController.m
@@ -453,6 +453,7 @@ void uncaughtExceptionHandler(NSException *exception)
     {
         [actionsheet addAction:[UIAlertAction actionWithTitle:@"Swap Disk" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [[weakSelf emulatorCore] swapDisk];
+            weakSelf.isShowingMenu = NO;
         }]];
     }
 


### PR DESCRIPTION
isShowingMenu was not being reset after hitting swap disk. Fixes #342 