### PR TITLE
Add basic gameplay recording

### DIFF
--- a/Provenance/Provenance-Info.plist
+++ b/Provenance/Provenance-Info.plist
@@ -38,7 +38,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>418</string>
+	<string>429</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Provenance/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Provenance/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,6 +1,16 @@
 {
   "images" : [
     {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
       "size" : "29x29",
       "idiom" : "iphone",
       "filename" : "Icon-29@2x-1.png",
@@ -35,6 +45,16 @@
       "idiom" : "iphone",
       "filename" : "Icon-60@3x.png",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
     },
     {
       "size" : "29x29",


### PR DESCRIPTION
Added a simple option to the emulation menu that lets users record their gameplay using ReplayKit. Here's an [example recording](https://www.dropbox.com/s/zf7985auypov8w1/IMG_0052.MP4?dl=0).