### PR TITLE
8bitdo nes30 controller name

### DIFF
--- a/Provenance/Controller/iCade/kICadeControllerSetting.m
+++ b/Provenance/Controller/iCade/kICadeControllerSetting.m
@@ -21,7 +21,7 @@ NSString* kIcadeControllerSettingToString(kICadeControllerSetting value) {
             stringRepresentation = @"Standard Controller";
             break;
         case kICadeControllerSetting8Bitdo:
-            stringRepresentation = @"8bitdo Controller";
+            stringRepresentation = @"8Bitdo Controller";
             break;
         case kICadeControllerSettingSteelSeries:
             stringRepresentation = @"SteelSeries Free Controller";

--- a/Provenance/Controller/iCade/kICadeControllerSetting.m
+++ b/Provenance/Controller/iCade/kICadeControllerSetting.m
@@ -21,7 +21,7 @@ NSString* kIcadeControllerSettingToString(kICadeControllerSetting value) {
             stringRepresentation = @"Standard Controller";
             break;
         case kICadeControllerSetting8Bitdo:
-            stringRepresentation = @"8bitdo Nes30 Controller";
+            stringRepresentation = @"8bitdo Controller";
             break;
         case kICadeControllerSettingSteelSeries:
             stringRepresentation = @"SteelSeries Free Controller";


### PR DESCRIPTION
Renamed 8bitdo controller to match official name (8Bitdo), and removed unnecessarily specific "nes30" part of the name.