### PR TITLE
Better (more inclusive) iPhone 7 (7 Plus) detection. (Used for taptic…

### DIFF
--- a/Provenance/Categories/UIDevice+Hardware.h
+++ b/Provenance/Categories/UIDevice+Hardware.h
@@ -11,5 +11,6 @@
 @interface UIDevice (Hardware)
 
 - (NSString *)modelIdentifier;
++ (BOOL)isIphone7or7Plus;
 
 @end

--- a/Provenance/Categories/UIDevice+Hardware.m
+++ b/Provenance/Categories/UIDevice+Hardware.m
@@ -30,4 +30,19 @@
 	return [self getSysInfoByName:"hw.machine"];
 }
 
+///All known Device Types for iPhone 7 or iPhone 7 Plus
++ (BOOL)isIphone7or7Plus
+{
+    if ([[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,1"] ||    //iPhone 7 (A1660/A1779/A1780)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,2"] ||    //iPhone 7 Plus (A1661/A1785/A1786)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,3"] ||    //iPhone 7 (A1778)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,4"]) {    //iPhone 7 Plus (A1784)
+        
+        return YES;
+    }
+    else {
+        return NO;
+    }
+}
+
 @end

--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -376,8 +376,7 @@ void AudioServicesPlaySystemSoundWithVibration(int, id, NSDictionary *);
 	{
 		// only iPhone 7 and 7 Plus support the taptic engine APIs for now.
 		// everything else should fall back to the vibration motor.
-		if ([[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,2"] ||
-			[[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,3"])
+		if ([UIDevice isIphone7or7Plus])
 		{
 			[self.feedbackGenerator selectionChanged];
 		}


### PR DESCRIPTION
… engine)

The existing implementation was missing two device types. Also encapsulated this check in the UIDevice+Hardware category.