### PR TITLE
Handle 8Bitdo disconnect and reconnect.

### DIFF
--- a/Provenance/Controller/PVControllerManager.m
+++ b/Provenance/Controller/PVControllerManager.m
@@ -10,6 +10,7 @@
 #import "PVSettingsModel.h"
 #import "PViCadeController.h"
 #import "kICadeControllerSetting.h"
+#import "PViCade8BitdoController.h"
 
 NSString * const PVControllerManagerControllerReassignedNotification = @"PVControllerManagerControllerReassignedNotification";
 
@@ -101,8 +102,20 @@ NSString * const PVControllerManagerControllerReassignedNotification = @"PVContr
         self.player2 = nil;
     }
     
-    // Reassign any controller which we are unassigned
-    BOOL assigned = [self assignControllers];
+    BOOL assigned = NO;
+    if ([controller isKindOfClass:[PViCade8BitdoController class]]) {
+        // For 8Bitdo, we set to listen again for controllers after disconnecting
+        // so we can detect when they connect again
+        if (self.iCadeController) {
+            [self listenForICadeControllers];
+        }
+    }
+    else {
+        // Reassign any controller which we are unassigned
+        // (we don't do this for 8Bitdo, instead we listen for them to connect)
+        assigned = [self assignControllers];
+    }
+    
     if (!assigned) {
         [[NSNotificationCenter defaultCenter] postNotificationName:PVControllerManagerControllerReassignedNotification
                                                             object:self];


### PR DESCRIPTION
When tapping Disconnect iCade, it brings the on-screen controller back. Reconnecting iCade hides it again.
