### PR TITLE
Corrections to README and SG-1000 Controls

### DIFF
--- a/Provenance/Resources/systems.plist
+++ b/Provenance/Resources/systems.plist
@@ -771,17 +771,17 @@
 						<key>PVControlType</key>
 						<string>PVButton</string>
 						<key>PVControlTitle</key>
-						<string>A</string>
+						<string>1</string>
 						<key>PVControlFrame</key>
-						<string>{{116,60},{60,60}}</string>
+						<string>{{4,60},{60,60}}</string>
 					</dict>
 					<dict>
 						<key>PVControlType</key>
 						<string>PVButton</string>
 						<key>PVControlTitle</key>
-						<string>B</string>
+						<string>2</string>
 						<key>PVControlFrame</key>
-						<string>{{60,116},{60,60}}</string>
+						<string>{{116,60},{60,60}}</string>
 					</dict>
 				</array>
 			</dict>

--- a/README.mdown
+++ b/README.mdown
@@ -2,7 +2,7 @@
 An iOS & tvOS Frontend for multiple emulators
 
 ###Building Provenance
-[See the instructions on the wiki](https://github.com/jasarien/Provenance/wiki/Building-Provenance) And follow them _to the letter_. Any issues raised that clearly demonstrate that the instructions haven't been followed will be closed.
+[See the instructions on the wiki](https://github.com/jasarien/Provenance/wiki/Building-Provenance) and follow them _to the letter_. Any issues raised that clearly demonstrate that the instructions haven't been followed will be closed.
 
 ###Why 'Provenance'?
 
@@ -22,7 +22,7 @@ I was looking for a word with a similar meaning to Genesis and came across Prove
     - MegaCD [See wiki](https://github.com/jasarien/Provenance/wiki/Sega-MegaCD-Instructions)
     - Game Gear
 - Nintendo
-    - NES
+    - NES (Nintendo Entertainment System)
     - Famicom Disk System [See Wiki](https://github.com/jasarien/Provenance/wiki/Famicom-Disk-System-Instructions)
     - SNES (Super Nintendo)
     - Gameboy / Gameboy Color
@@ -50,14 +50,12 @@ I was looking for a word with a similar meaning to Genesis and came across Prove
     - Custom artwork is also supported
 - Game library searching
 - Supports iOS 8+
-    - 3D Touch shortcuts for recent games on iPhone 6S/Plus
+    - 3D Touch shortcuts for recent games (iPhone 6s and later)
+    - Taptic Engine Feedback for button presses (iPhone 7 and later)
 - Supports Apple TV tvOS 9+
-    - TopShelf support
+    - TopShelf support [See instructions](https://github.com/jasarien/Provenance/pull/242)
 
 Feel free to suggest/request features using the Issues page, but please read all issues (open *and* closed) before raising new ones to avoid duplicates.
-
-Please note that this is an open source project done in the free time of the author and contributors and new features and new emulator cores may take time.
-Adding a comment to an existing issue does not help speed up the development in any way.
 
 ###Importing ROMs
 [See the instructions on the wiki](https://github.com/jasarien/Provenance/wiki/Importing-ROMs)
@@ -70,7 +68,7 @@ If you're a contributor, or would like to contribute, there is a developer-focus
 
 #Attributions
 
-Sega system emulation is provided by [Genesis Plus GX](http://code.google.com/p/genplus-gx/), originally written by Charles Mac Donald, and later improved by Eke-Eke.
+Sega system emulation is provided by [Genesis Plus GX](https://bitbucket.org/eke/genesis-plus-gx/), originally written by Charles Mac Donald, and later improved by Eke-Eke.
 
 NES/Famicom Disk System emulation is provided by [FCEUX](http://www.fceux.com/web/home.html).
 


### PR DESCRIPTION
A bit strange to have these both in a  single pull request, but I did not feel right with just a README correction pull request.

This has a few minor corrections/additions to the README such as Taptic Engine Feedback.

However, the main reason for this pull request is to correct the SG-1000 controls.  I was able to obtain a Test Cartridge Rom and realized that the second button was actually not working.  I also moved the buttons to be horizontally next to each other to more accurately match a real controller.
