### PR TITLE
Fix some missing punctuation in README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -84,9 +84,9 @@ Gameboy/Gameboy Color emulation is provided by [Gambatte](http://gambatte.source
 
 Atari 2600 emulation is provided by [Stella](http://stella.sourceforge.net/).
 
-Atari 7800 emulation is provided by [ProSystem](http://gstanton.github.io/ProSystem1_3/)
+Atari 7800 emulation is provided by [ProSystem](http://gstanton.github.io/ProSystem1_3/).
 
-Sega 32X emulation is provided by [PicoDrive](https://github.com/notaz/picodrive)
+Sega 32X emulation is provided by [PicoDrive](https://github.com/notaz/picodrive).
 
 The specific implementations used in Provenance are loosely based on some of the work done by [OpenEmu](http://openemu.org) [(source)](http://github.com/OpenEmu) and [RetroArch](http://www.libretro.com) [(source)](https://github.com/libretro/RetroArch).
 


### PR DESCRIPTION
Title explains it.
These were introduced in the README when JoeMatt's Atari & 32X emulators were merged.