### PR TITLE
Ability to Change Cover Art via Web Server’s UI

### DIFF
--- a/Provenance/Game Library/PVGameImporter.h
+++ b/Provenance/Game Library/PVGameImporter.h
@@ -13,6 +13,8 @@ typedef void (^PVGameImporterCompletionHandler)(BOOL encounteredConflicts);
 typedef void (^PVGameImporterFinishedImportingGameHandler)(NSString *md5Hash);
 typedef void (^PVGameImporterFinishedGettingArtworkHandler)(NSString *artworkURL);
 
+@class PVGame;
+
 @interface PVGameImporter : NSObject
 
 @property (nonatomic, readonly, strong) dispatch_queue_t serialImportQueue;
@@ -32,5 +34,15 @@ typedef void (^PVGameImporterFinishedGettingArtworkHandler)(NSString *artworkURL
 
 - (void)getRomInfoForFilesAtPaths:(NSArray *)paths userChosenSystem:(NSString *)systemID;
 - (void)getArtworkFromURL:(NSString *)url;
+
+/**
+ Import a specifically named image file to the matching game.
+ 
+ To update “Kart Fighter.nes”, use an image named “Kart Fighter.nes.png”.
+
+ @param imageFullPath The artwork image path
+ @return The game that was updated
+ */
++ (PVGame *)importArtworkFromPath:(NSString *)imageFullPath;
 
 @end

--- a/Provenance/Game Library/PVGameImporter.m
+++ b/Provenance/Game Library/PVGameImporter.m
@@ -15,6 +15,9 @@
 #import <Realm/Realm.h>
 #import "PVSynchronousURLSession.h"
 #import "PVEmulatorConstants.h"
+#import "PVAppConstants.h"
+#import "UIImage+Scaling.h"
+#import "NSData+Hashing.h"
 
 @interface PVGameImporter ()
 
@@ -670,6 +673,65 @@
     }
     
     return isCDROM;
+}
+
+#pragma mark -
+
++ (PVGame *)importArtworkFromPath:(NSString *)imageFullPath
+{
+    BOOL isDirectory = NO;
+
+    if (![NSFileManager.defaultManager fileExistsAtPath:imageFullPath isDirectory:&isDirectory] || isDirectory) {
+        return nil;
+    }
+
+    NSData *coverArtFullData = [NSData dataWithContentsOfFile:imageFullPath];
+    UIImage *coverArtFullImage = [UIImage imageWithData:coverArtFullData];
+    UIImage *coverArtScaledImage = [coverArtFullImage scaledImageWithMaxResolution:PVThumbnailMaxResolution];
+
+    if (!coverArtScaledImage) {
+        return nil;
+    }
+
+    NSData *coverArtScaledData = UIImagePNGRepresentation(coverArtScaledImage);
+    NSString *hash = [coverArtScaledData md5Hash];
+    [PVMediaCache writeDataToDisk:coverArtScaledData withKey:hash];
+
+    NSString *imageFilename = imageFullPath.lastPathComponent;
+    NSString *imageFileExtension = [@"." stringByAppendingString:imageFilename.pathExtension];
+    NSString *gameFilename = [imageFilename stringByReplacingOccurrencesOfString:imageFileExtension withString:@""];
+
+    NSString *systemID = [PVEmulatorConfiguration.sharedInstance systemIdentifierForFileExtension:gameFilename.pathExtension];
+    NSArray *cdBasedSystems = [[PVEmulatorConfiguration sharedInstance] cdBasedSystemIDs];
+
+    if ([cdBasedSystems containsObject:systemID] && ![gameFilename.pathExtension isEqualToString:@"cue"]) {
+        return nil;
+    }
+
+    NSString *gamePartialPath = [systemID stringByAppendingPathComponent:gameFilename];
+
+    if (!gamePartialPath) {
+        return nil;
+    }
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+
+    NSPredicate *gamePredicate = [NSPredicate predicateWithFormat:@"romPath == %@", gamePartialPath];
+    RLMResults *games = [PVGame objectsInRealm:realm withPredicate:gamePredicate];
+
+    if (games.count < 1) {
+        return nil;
+    }
+
+    PVGame *game = games.firstObject;
+
+    [realm beginWriteTransaction];
+    [game setCustomArtworkURL:hash];
+    [realm commitWriteTransaction];
+
+    [NSFileManager.defaultManager removeItemAtPath:imageFullPath error:nil];
+
+    return game;
 }
 
 @end

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -546,10 +546,25 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
     [self.watcher startMonitoring];
 
     self.coverArtWatcher = [[PVDirectoryWatcher alloc] initWithPath:self.coverArtPath extractionStartedHandler:^(NSString *path) {
-        //
+        MBProgressHUD *hud = [MBProgressHUD HUDForView:weakSelf.view];
+
+        if (!hud) {
+            hud = [MBProgressHUD showHUDAddedTo:weakSelf.view animated:YES];
+        }
+
+        [hud setUserInteractionEnabled:NO];
+        [hud setMode:MBProgressHUDModeAnnularDeterminate];
+        [hud setProgress:0];
+        [hud setLabelText:@"Extracting Archive…"];
     } extractionUpdatedHandler:^(NSString *path, NSInteger entryNumber, NSInteger total, unsigned long long fileSize, unsigned long long bytesRead) {
-        //
+        MBProgressHUD *hud = [MBProgressHUD HUDForView:weakSelf.view];
+        [hud setProgress:(float)bytesRead / (float)fileSize];
     } extractionCompleteHandler:^(NSArray *paths) {
+        MBProgressHUD *hud = [MBProgressHUD HUDForView:weakSelf.view];
+        [hud setProgress:1];
+        [hud setLabelText:@"Extraction Complete!"];
+        [hud hide:YES afterDelay:0.5];
+
         for (NSString *imageFilepath in paths) {
             NSString *imageFullPath = [weakSelf.coverArtPath stringByAppendingPathComponent:imageFilepath];
             PVGame *game = [PVGameImporter importArtworkFromPath:imageFullPath];

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -581,7 +581,13 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
             }
 
             NSString *gamePartialPath = [systemID stringByAppendingPathComponent:gameFilename];
-            RLMResults *games = [PVGame objectsInRealm:weakSelf.realm withPredicate:[NSPredicate predicateWithFormat:@"romPath == %@", gamePartialPath]];
+
+            if (!gamePartialPath) {
+                continue;
+            }
+
+            NSPredicate *gamePredicate = [NSPredicate predicateWithFormat:@"romPath == %@", gamePartialPath];
+            RLMResults *games = [PVGame objectsInRealm:weakSelf.realm withPredicate:gamePredicate];
 
             if (games.count < 1) {
                 continue;

--- a/Provenance/http/GCDWebUploader/GCDWebUploader.bundle/index.html
+++ b/Provenance/http/GCDWebUploader/GCDWebUploader.bundle/index.html
@@ -64,6 +64,11 @@
           <h3>Upload New ROMs</h3>
           <p>You can upload new ROMs by uploading *.zip files into the roms/ directory. Then close the web server and Provenance will attempt to import them.</p>
       </div>
+
+      <div>
+          <h3>Upload New Artwork</h3>
+          <p>You can upload new cover art images by uploading *.zip files into the Cover Art/ directory. Then close the web server and Provenance will attempt to import them.</p>
+      </div>
       
       <div>
           <h3>Transfer Game Saves</h3>

--- a/Provenance/http/GCDWebUploader/GCDWebUploader.bundle/index.html
+++ b/Provenance/http/GCDWebUploader/GCDWebUploader.bundle/index.html
@@ -67,7 +67,7 @@
 
       <div>
           <h3>Upload New Artwork</h3>
-          <p>You can upload new cover art images by uploading *.zip files into the Cover Art/ directory. Then close the web server and Provenance will attempt to import them.</p>
+          <p>You can upload new cover art images by uploading a *.zip file into the Cover Art/ directory. The images need to be named the same as their ROM (IE, “kart fighter.nes.png” will update the artwork on “kart fighter.nes”. ROM Filenames can be found in the “com.provenance.*” directories). Then close the web server and Provenance will attempt to import them.</p>
       </div>
       
       <div>


### PR DESCRIPTION
Adds a directory watcher, similar to the ROMs directory watcher, that will import image file to matching game cover art.

> You can upload new cover art images by uploading a *.zip file into the Cover Art/ directory. The images need to be named the same as their ROM (IE, “kart fighter.nes.png” will update the artwork on “kart fighter.nes”. ROM Filenames can be found in the “com.provenance.*” directories). Then close the web server and Provenance will attempt to import them.

Issue #286