### PR TITLE
Fix Issue #311 by ensuring that gestures for Menu presses on tvOS are…

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.m
+++ b/Provenance/Emulator/PVEmulatorViewController.m
@@ -805,6 +805,20 @@ void uncaughtExceptionHandler(NSException *exception)
 
 #pragma mark - Controllers
 
+#if TARGET_OS_TV
+// Ensure that override of menu gesture is caught and handled properly for tvOS
+-(void)pressesBegan:(NSSet<UIPress *> *)presses withEvent:(nullable UIPressesEvent *)event {
+    
+    UIPress *press = (UIPress *)presses.anyObject;
+    if ( press && press.type == UIPressTypeMenu && !self.isShowingMenu )
+    {
+        [self controllerPauseButtonPressed];
+    }
+    else
+        [super pressesBegan:presses withEvent:event];
+}
+#endif 
+
 - (void)controllerPauseButtonPressed
 {
 	dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
… caught and handled appropriately.

This should allow you to press the 'Menu' button on both the controller and the remote from the game menu without being kicked back out to the TopShelf view.  Smoke testing of various areas of app using menu button shows this works well and kicks you back to navigator then springboard from TopShelf view as expected.

Warning: Tested only on 10.1 with a SteelSeries Nimbus controller and the stock AppleTV 4 remote.  