### PR TITLE
D-Pad stays pressed with touchDown outside until touchup + Disable D-pad Diagonals Option

### DIFF
--- a/Provenance/Controller/JSDPad.h
+++ b/Provenance/Controller/JSDPad.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSUInteger, JSDPadDirection)
 @interface JSDPad : UIView
 
 @property (nonatomic, weak) IBOutlet id <JSDPadDelegate> delegate;
+@property (nonatomic) BOOL diagonalDirectionsEnabled;
 
 - (void)setEnabled:(BOOL)enabled;
 - (JSDPadDirection)currentDirection;

--- a/Provenance/Controller/JSDPad.m
+++ b/Provenance/Controller/JSDPad.m
@@ -20,6 +20,8 @@
 
 @implementation JSDPad
 
+@synthesize diagonalDirectionsEnabled;
+
 - (id)initWithFrame:(CGRect)frame
 {
 	if ((self = [super initWithFrame:frame]))
@@ -47,6 +49,7 @@
 	[self addSubview:_dPadImageView];
 	
 	_currentDirection = JSDPadDirectionNone;
+    diagonalDirectionsEnabled = YES;
 }
 
 - (void)dealloc
@@ -68,19 +71,26 @@
 {
 	CGFloat x = point.x;
 	CGFloat y = point.y;
-	
-	if (((x < 0) || (x > [self bounds].size.width)) ||
-		((y < 0) || (y > [self bounds].size.height)))
-	{
-		return JSDPadDirectionNone;
-	}
-	
-	NSUInteger column = x / ([self bounds].size.width / 3);
-	NSUInteger row = y / ([self bounds].size.height / 3);
-
-	JSDPadDirection direction = (row * 3) + column + 1;
-	
-	return direction;
+    
+    if (diagonalDirectionsEnabled) {
+        NSUInteger column = MAX(0, MIN(2, x / (self.bounds.size.width / 3)));
+        NSUInteger row = MAX(0, MIN(2, y / (self.bounds.size.height / 3)));
+        return (row * 3) + column + 1;
+    } else {
+        CGPoint offset = CGPointMake(x - self.bounds.size.width / 2, y - self.bounds.size.height / 2);
+        CGFloat angle = atan2(offset.y, offset.x) + M_PI;
+        if (angle < M_PI_4) {
+            return JSDPadDirectionLeft;
+        } else if (angle < M_PI_2 + M_PI_4) {
+            return JSDPadDirectionUp;
+        } else if (angle < M_PI + M_PI_4) {
+            return JSDPadDirectionRight;
+        } else if (angle < M_PI + M_PI_2 + M_PI_4) {
+            return JSDPadDirectionDown;
+        } else {
+            return JSDPadDirectionLeft;
+        }
+    }
 }
 
 - (UIImage *)imageForDirection:(JSDPadDirection)direction

--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -136,10 +136,14 @@
 			CGSize size = CGSizeFromString([control objectForKey:PVControlSizeKey]);
 			CGFloat dPadOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - size.height - bottomPadding);
 			CGRect dPadFrame = CGRectMake(xPadding, dPadOriginY, size.width, size.height);
+            NSNumber *diagonalDirectionsEnabled = (NSNumber *)[control objectForKey:PVControlDiagonalDirectionsEnabledKey];
 			
 			if (!self.dPad)
 			{
 				self.dPad = [[JSDPad alloc] initWithFrame:dPadFrame];
+                if (diagonalDirectionsEnabled) {
+                    self.dPad.diagonalDirectionsEnabled = diagonalDirectionsEnabled.boolValue;
+                }
 				[self.dPad setDelegate:self];
 				[self.dPad setAlpha:alpha];
 				[self.dPad setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin];

--- a/Provenance/Emulator/PVEmulatorConstants.h
+++ b/Provenance/Emulator/PVEmulatorConstants.h
@@ -19,6 +19,7 @@ extern NSString * const PVSupportedExtensionsKey;
 extern NSString * const PVControlLayoutKey;
 extern NSString * const PVControlTypeKey;
 extern NSString * const PVControlSizeKey;
+extern NSString * const PVControlDiagonalDirectionsEnabledKey;
 extern NSString * const PVGroupedButtonsKey;
 extern NSString * const PVControlFrameKey;
 extern NSString * const PVControlTitleKey;

--- a/Provenance/Emulator/PVEmulatorConstants.m
+++ b/Provenance/Emulator/PVEmulatorConstants.m
@@ -19,6 +19,7 @@ NSString * const PVSupportedExtensionsKey = @"PVSupportedExtensions";
 NSString * const PVControlLayoutKey       = @"PVControlLayout";
 NSString * const PVControlTypeKey         = @"PVControlType";
 NSString * const PVControlSizeKey         = @"PVControlSize";
+NSString * const PVControlDiagonalDirectionsEnabledKey = @"PVControlDiagonalDirectionsEnabled";
 NSString * const PVGroupedButtonsKey      = @"PVGroupedButtons";
 NSString * const PVControlFrameKey        = @"PVControlFrame";
 NSString * const PVControlTitleKey        = @"PVControlTitle";

--- a/Provenance/Resources/systems.plist
+++ b/Provenance/Resources/systems.plist
@@ -447,6 +447,8 @@
 				<string>PVDPad</string>
 				<key>PVControlSize</key>
 				<string>{180,180}</string>
+				<key>PVControlDiagonalDirectionsEnabled</key>
+				<false/>
 			</dict>
 			<dict>
 				<key>PVControlType</key>


### PR DESCRIPTION
When pressing the D-Pad and then dragging outside its area, the direction now remains pressed. I found this more convenient to play, since without physical buttons the control area is easy to leave with the thumb.

I also added the option to disable diagonal directions of the D-Pad on systems that do not support it even on the physical device, such as the Gameboy Advance. For this I added the `PVControlDiagonalDirectionsEnabled` key in `PVEmulatorConstants.h`. The key can be added with a boolean value to any dictionary of `PVDPad` control type in the `systems.plist` that describes the emulated devices. So far I only added it to the Gameboy Advance.

Both changes make it more natural to play on Gameboy Advance, I found. Any comments on this?