### PR TITLE
8bitdo Zero Controller Support

### DIFF
--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -279,6 +279,8 @@
 		BEB41B3B1CAB01D6009E0B7E /* PVGame+Sizing.m in Sources */ = {isa = PBXBuildFile; fileRef = BEB41B3A1CAB01D6009E0B7E /* PVGame+Sizing.m */; };
 		BEC075CD1C221F3A00305027 /* RLMRealmConfiguration+Config.m in Sources */ = {isa = PBXBuildFile; fileRef = BEC075CC1C221F3A00305027 /* RLMRealmConfiguration+Config.m */; };
 		BEC075CE1C221F3A00305027 /* RLMRealmConfiguration+Config.m in Sources */ = {isa = PBXBuildFile; fileRef = BEC075CC1C221F3A00305027 /* RLMRealmConfiguration+Config.m */; };
+		DA23818D1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA23818C1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m */; };
+		DA23818E1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA23818C1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m */; };
 		E414488B1B3125D90056D80A /* iCadeReaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = E41448891B3125D90056D80A /* iCadeReaderView.m */; };
 		E414488E1B3126190056D80A /* PViCadeGamepad.m in Sources */ = {isa = PBXBuildFile; fileRef = E414488D1B3126190056D80A /* PViCadeGamepad.m */; };
 		E41448911B34B9600056D80A /* PViCadeController.m in Sources */ = {isa = PBXBuildFile; fileRef = E41448901B34B9600056D80A /* PViCadeController.m */; };
@@ -600,6 +602,8 @@
 		BEB41B3A1CAB01D6009E0B7E /* PVGame+Sizing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PVGame+Sizing.m"; sourceTree = "<group>"; };
 		BEC075CB1C221F3A00305027 /* RLMRealmConfiguration+Config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMRealmConfiguration+Config.h"; sourceTree = "<group>"; };
 		BEC075CC1C221F3A00305027 /* RLMRealmConfiguration+Config.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMRealmConfiguration+Config.m"; sourceTree = "<group>"; };
+		DA23818B1F09D21F00D5FC09 /* PViCade8BitdoZeroController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PViCade8BitdoZeroController.h; sourceTree = "<group>"; };
+		DA23818C1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PViCade8BitdoZeroController.m; sourceTree = "<group>"; };
 		E41448881B3125D90056D80A /* iCadeReaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iCadeReaderView.h; sourceTree = "<group>"; };
 		E41448891B3125D90056D80A /* iCadeReaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iCadeReaderView.m; sourceTree = "<group>"; };
 		E414488A1B3125D90056D80A /* iCadeState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iCadeState.h; sourceTree = "<group>"; };
@@ -1270,6 +1274,8 @@
 				E41448901B34B9600056D80A /* PViCadeController.m */,
 				E4F936981B50829F009403C5 /* PViCade8BitdoController.h */,
 				E4F936991B50829F009403C5 /* PViCade8BitdoController.m */,
+				DA23818B1F09D21F00D5FC09 /* PViCade8BitdoZeroController.h */,
+				DA23818C1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m */,
 				F43211981BFB6AB300387909 /* PViCadeSteelSeriesController.h */,
 				F43211991BFB6AB300387909 /* PViCadeSteelSeriesController.m */,
 				E41448921B34BBAB0056D80A /* PViCadeReader.h */,
@@ -1613,6 +1619,7 @@
 				1FB125961D93E57F00D045D0 /* PVAppearanceViewController.m in Sources */,
 				1A9647B117D6864300A55612 /* PVControllerViewController.m in Sources */,
 				E414489D1B34C4E50056D80A /* PViCadeInputAxis.m in Sources */,
+				DA23818D1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m in Sources */,
 				1ADB316517D9341600DB6043 /* PVGenesisControllerViewController.m in Sources */,
 				B3DF87651D6A5A5300D216D4 /* PVStellaControllerViewController.m in Sources */,
 				378F4A091B63D7CD0065FA39 /* GCDWebServerDataResponse.m in Sources */,
@@ -1680,6 +1687,7 @@
 				1AD481D71BA3543500FDA50A /* GCDWebServer.m in Sources */,
 				B3DF87661D6A5A5300D216D4 /* PVStellaControllerViewController.m in Sources */,
 				1AD481FC1BA354B100FDA50A /* PViCade8BitdoController.m in Sources */,
+				DA23818E1F09D21F00D5FC09 /* PViCade8BitdoZeroController.m in Sources */,
 				1AD481F51BA3549C00FDA50A /* UIImage+Scaling.m in Sources */,
 				1AD481DE1BA3544A00FDA50A /* GCDWebServerMultiPartFormRequest.m in Sources */,
 				1AD481DA1BA3543E00FDA50A /* GCDWebServerRequest.m in Sources */,

--- a/Provenance/Controller/PVControllerManager.m
+++ b/Provenance/Controller/PVControllerManager.m
@@ -11,6 +11,7 @@
 #import "PViCadeController.h"
 #import "kICadeControllerSetting.h"
 #import "PViCade8BitdoController.h"
+#import "PViCade8BitdoZeroController.h"
 #import "PViCadeController.h"
 
 NSString * const PVControllerManagerControllerReassignedNotification = @"PVControllerManagerControllerReassignedNotification";
@@ -111,7 +112,7 @@ NSString * const PVControllerManagerControllerReassignedNotification = @"PVContr
     }
     
     BOOL assigned = NO;
-    if ([controller isKindOfClass:[PViCade8BitdoController class]]) {
+    if ([controller isKindOfClass:[PViCade8BitdoController class]] || [controller isKindOfClass:[PViCade8BitdoZeroController class]]) {
         // For 8Bitdo, we set to listen again for controllers after disconnecting
         // so we can detect when they connect again
         if (self.iCadeController) {

--- a/Provenance/Controller/iCade/PViCade8BitdoZeroController.h
+++ b/Provenance/Controller/iCade/PViCade8BitdoZeroController.h
@@ -1,0 +1,13 @@
+//
+//  PViCade8BitdoZeroController.h
+//  Provenance
+//
+//  Created by Justin Weiss on 7/2/17.
+//  Copyright © 2017 Justin Weiss. All rights reserved.
+//
+
+#import "PViCadeController.h"
+
+@interface PViCade8BitdoZeroController : PViCadeController
+
+@end

--- a/Provenance/Controller/iCade/PViCade8BitdoZeroController.m
+++ b/Provenance/Controller/iCade/PViCade8BitdoZeroController.m
@@ -1,0 +1,103 @@
+//
+//  PViCade8BitdoZeroController.m
+//  Provenance
+//
+//  Created by Justin Weiss on 7/2/17.
+//  Copyright © 2017 Justin Weiss. All rights reserved.
+//
+
+#import "PViCade8BitdoZeroController.h"
+#import "PViCadeGamepad.h"
+#import "PViCadeGamepadButtonInput.h"
+#import "PViCadeGamepadDirectionPad.h"
+
+@implementation PViCade8BitdoZeroController
+
+-(instancetype) init {
+    if (self = [super init]) {
+        __unsafe_unretained PViCadeController* weakSelf = self;
+        self.reader.buttonDown = ^(iCadeState button) {
+            switch (button) {
+                case iCadeButtonA:
+                    [[weakSelf.iCadeGamepad buttonY] buttonPressed];
+                    break;
+                case iCadeButtonB:
+                    [[weakSelf.iCadeGamepad buttonB] buttonPressed];
+                    break;
+                case iCadeButtonC:
+                    [[weakSelf.iCadeGamepad buttonA] buttonPressed];
+                    break;
+                case iCadeButtonD:
+                    [[weakSelf.iCadeGamepad buttonX] buttonPressed];
+                    break;
+                case iCadeButtonE:
+                    [[weakSelf.iCadeGamepad rightShoulder] buttonPressed];
+                    break;
+                case iCadeButtonF:
+                    [[weakSelf.iCadeGamepad leftShoulder] buttonPressed];
+                    break;
+                case iCadeButtonG:
+                    [[weakSelf.iCadeGamepad leftTrigger] buttonPressed];
+                    break;
+                case iCadeButtonH:
+                    [[weakSelf.iCadeGamepad rightTrigger] buttonPressed];
+                    break;
+                case iCadeJoystickDown:
+                case iCadeJoystickLeft:
+                case iCadeJoystickRight:
+                case iCadeJoystickUp:
+                    [[weakSelf.iCadeGamepad dpad] padChanged];
+                    break;
+                default:
+                    break;
+            }
+            if (weakSelf.controllerPressedAnyKey) {
+                weakSelf.controllerPressedAnyKey(weakSelf);
+            }
+        };
+        
+        self.reader.buttonUp = ^(iCadeState button) {
+            switch (button) {
+                case iCadeButtonA:
+                    [[weakSelf.iCadeGamepad buttonY] buttonReleased];
+                    break;
+                case iCadeButtonB:
+                    [[weakSelf.iCadeGamepad buttonB] buttonReleased];
+                    break;
+                case iCadeButtonC:
+                    [[weakSelf.iCadeGamepad buttonA] buttonReleased];
+                    break;
+                case iCadeButtonD:
+                    [[weakSelf.iCadeGamepad buttonX] buttonReleased];
+                    break;
+                case iCadeButtonE:
+                    [[weakSelf.iCadeGamepad rightShoulder] buttonReleased];
+                    break;
+                case iCadeButtonF:
+                    [[weakSelf.iCadeGamepad leftShoulder] buttonReleased];
+                    break;
+                case iCadeButtonG:
+                    [[weakSelf.iCadeGamepad leftTrigger] buttonReleased];
+                    break;
+                case iCadeButtonH:
+                    [[weakSelf.iCadeGamepad rightTrigger] buttonReleased];
+                    break;
+                case iCadeJoystickDown:
+                case iCadeJoystickLeft:
+                case iCadeJoystickRight:
+                case iCadeJoystickUp:
+                    [[weakSelf.iCadeGamepad dpad] padChanged];
+                    break;
+                default:
+                    break;
+            }
+        };
+    }
+    return self;
+}
+
+- (NSString *) vendorName {
+    return @"8Bitdo Zero";
+}
+
+@end

--- a/Provenance/Controller/iCade/kICadeControllerSetting.h
+++ b/Provenance/Controller/iCade/kICadeControllerSetting.h
@@ -16,6 +16,7 @@ typedef NS_ENUM(NSUInteger, kICadeControllerSetting) {
     kICadeControllerSettingStandard,
     kICadeControllerSetting8Bitdo,
     kICadeControllerSettingSteelSeries,
+    kICadeControllerSetting8BitdoZero,
     kICadeControllerSetting_Count
 };
 

--- a/Provenance/Controller/iCade/kICadeControllerSetting.m
+++ b/Provenance/Controller/iCade/kICadeControllerSetting.m
@@ -8,6 +8,7 @@
 
 #include "kICadeControllerSetting.h"
 #import "PViCade8BitdoController.h"
+#import "PViCade8BitdoZeroController.h"
 #import "PViCadeSteelSeriesController.h"
 
 
@@ -25,6 +26,10 @@ NSString* kIcadeControllerSettingToString(kICadeControllerSetting value) {
             break;
         case kICadeControllerSettingSteelSeries:
             stringRepresentation = @"SteelSeries Free Controller";
+            break;
+        case kICadeControllerSetting8BitdoZero:
+            stringRepresentation = @"8Bitdo Zero Controller";
+            break;
         default:
             break;
     }
@@ -46,6 +51,9 @@ PViCadeController* kIcadeControllerSettingToPViCadeController(kICadeControllerSe
             break;
         case kICadeControllerSettingSteelSeries:
             controller = [[PViCadeSteelSeriesController alloc] init];
+            break;
+        case kICadeControllerSetting8BitdoZero:
+            controller = [[PViCade8BitdoZeroController alloc] init];
             break;
         default:
             break;

--- a/Provenance/Emulator/PVEmulatorViewController.m
+++ b/Provenance/Emulator/PVEmulatorViewController.m
@@ -22,6 +22,7 @@
 #import "PVEmulatorConfiguration.h"
 #import "PVControllerManager.h"
 #import "PViCade8BitdoController.h"
+#import "PViCade8BitdoZeroController.h"
 
 @interface PVEmulatorViewController ()
 
@@ -841,7 +842,7 @@ void uncaughtExceptionHandler(NSException *exception)
 {
     GCController *controller = [note object];
     // 8Bitdo controllers don't have a pause button, so don't hide the menu
-    if (![controller isKindOfClass:[PViCade8BitdoController class]]) {
+    if (![controller isKindOfClass:[PViCade8BitdoController class]] || ![controller isKindOfClass:[PViCade8BitdoZeroController class]]) {
         [self.menuButton setHidden:YES];
     }
 }


### PR DESCRIPTION
The 8bitdo Zero has its buttons reversed from other 8bitdo controllers -- On a SNES game, the bottom button acts like 'A', not 'B', and the top button acts like 'Y', not 'X'. This patch adds a new controller class for the 8bitdo Zero that maps the controller buttons to the correct inputs.