### PR TITLE
Speed up app launch (specially on large libraries)

### DIFF
--- a/Provenance/Game Library/PVGameImporter.h
+++ b/Provenance/Game Library/PVGameImporter.h
@@ -10,7 +10,7 @@
 
 typedef void (^PVGameImporterImportStartedHandler)(NSString *path);
 typedef void (^PVGameImporterCompletionHandler)(BOOL encounteredConflicts);
-typedef void (^PVGameImporterFinishedImportingGameHandler)(NSString *md5Hash);
+typedef void (^PVGameImporterFinishedImportingGameHandler)(NSString *md5Hash, BOOL modified);
 typedef void (^PVGameImporterFinishedGettingArtworkHandler)(NSString *artworkURL);
 
 @class PVGame;

--- a/Provenance/Game Library/PVGameImporter.m
+++ b/Provenance/Game Library/PVGameImporter.m
@@ -387,6 +387,7 @@
                 [realm commitWriteTransaction];
             }
 
+            BOOL modified = NO;
             if ([game requiresSync])
             {
                 if (self.importStartedHandler)
@@ -397,13 +398,14 @@
                 }
                 
                 [self lookupInfoForGame:game];
+                modified = YES;
             }
             
             if (self.finishedImportHandler)
             {
                 NSString *md5 = [game md5Hash];
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    self.finishedImportHandler(md5);
+                    self.finishedImportHandler(md5, modified);
                 });
             }
             

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -491,8 +491,10 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         [hud setMode:MBProgressHUDModeIndeterminate];
         [hud setLabelText:[NSString stringWithFormat:@"Importing %@", [path lastPathComponent]]];
     }];
-    [self.gameImporter setFinishedImportHandler:^(NSString *md5) {
-        [weakSelf finishedImportingGameWithMD5:md5];
+    [self.gameImporter setFinishedImportHandler:^(NSString *md5, BOOL modified) {
+        // This callback is always called,
+        // even if the started handler was not called because it didn't require a refresh.
+        [weakSelf finishedImportingGameWithMD5:md5 modified:modified];
     }];
     [self.gameImporter setFinishedArtworkHandler:^(NSString *url) {
         [weakSelf finishedDownloadingArtworkForURL:url];
@@ -642,13 +644,16 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
     self.mustRefreshDataSource = NO;
 }
 
-- (void)finishedImportingGameWithMD5:(NSString *)md5
+- (void)finishedImportingGameWithMD5:(NSString *)md5 modified:(BOOL)modified;
 {
     MBProgressHUD *hud = [MBProgressHUD HUDForView:self.view];
     [hud hide:YES];
 
-    [self fetchGames];
-    [self.collectionView reloadData];
+    // Only refresh the whole collection if game was modified.
+    if (modified) {
+        [self fetchGames];
+        [self.collectionView reloadData];
+    }
 
     // code below is simply to animate updates... currently crashy
 


### PR DESCRIPTION
Only trigger a library refresh if a rom lookup was triggered.

I've added 1888 nes/snes games to Provenance on an iPhone 6 and it would take 38 seconds to be responsive on launch. Now it's immediate.

I'm not sure why we run the game importer for each ROM that is already on the library, but the finish handler was called for each of those, which would trigger a library refresh (which can block the main thread for almost a second). I've modified the code to only refresh the library if the importer actually fetched new data for that ROM.

Library refresh speed can still be improved, but less than a second sounds OK to me right now.