### PR TITLE
Use Taptic Engine for iPhone 8 and iPhone X

### DIFF
--- a/Provenance/Categories/UIDevice+Hardware.h
+++ b/Provenance/Categories/UIDevice+Hardware.h
@@ -11,6 +11,6 @@
 @interface UIDevice (Hardware)
 
 - (NSString *)modelIdentifier;
-+ (BOOL)isIphone7or7Plus;
++ (BOOL)hasTapticMotor;
 
 @end

--- a/Provenance/Categories/UIDevice+Hardware.m
+++ b/Provenance/Categories/UIDevice+Hardware.m
@@ -31,13 +31,18 @@
 }
 
 ///All known Device Types for iPhone 7 or iPhone 7 Plus
-+ (BOOL)isIphone7or7Plus
++ (BOOL)hasTapticMotor
 {
-    if ([[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,1"] ||    //iPhone 7 (A1660/A1779/A1780)
-        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,2"] ||    //iPhone 7 Plus (A1661/A1785/A1786)
-        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,3"] ||    //iPhone 7 (A1778)
-        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,4"]) {    //iPhone 7 Plus (A1784)
-        
+    if ([[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,1"]  ||    //iPhone 7 (A1660/A1779/A1780)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,2"]  ||    //iPhone 7 Plus (A1661/A1785/A1786)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,3"]  ||    //iPhone 7 (A1778)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone9,4"]  ||    //iPhone 7 Plus (A1784)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone10,1"] ||    //iPhone 8 (A1863/A1906/A1907)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone10,4"] ||    //iPhone 8 (A1905)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone10,2"] ||    //iPhone 8 Plus (A1864/A1898/A1899)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone10,5"] ||    //iPhone 8 Plus (A1897)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone10,3"] ||    //iPhone X (A1865/A1902)
+        [[[UIDevice currentDevice] modelIdentifier] isEqualToString:@"iPhone10,6"]) {    //iPhone X (A1901)
         return YES;
     }
     else {

--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -371,7 +371,7 @@ void AudioServicesPlaySystemSoundWithVibration(int, id, NSDictionary *);
 	{
 		// only iPhone 7 and 7 Plus support the taptic engine APIs for now.
 		// everything else should fall back to the vibration motor.
-		if ([UIDevice isIphone7or7Plus])
+		if ([UIDevice hasTapticMotor])
 		{
 			[self.feedbackGenerator selectionChanged];
 		}


### PR DESCRIPTION
I converted the "isIphone7or7Plus" method to be a more general "hasTapticMotor" method and added the new model ID's for the iPhone 8, iPhone 8 Plus and iPhone X.