### PR TITLE
Feature/iphone x controls layout

### DIFF
--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -119,6 +119,12 @@
 - (void)setupTouchControls
 {
 #if !TARGET_OS_TV
+    
+    UIEdgeInsets safeAreaInsets = UIEdgeInsetsZero;
+    if (@available(iOS 11.0, *)) {
+        safeAreaInsets = self.view.safeAreaInsets;
+    }
+    
 	CGFloat alpha = [[PVSettingsModel sharedInstance] controllerOpacity];
 	
 	for (NSDictionary *control in self.controlLayout)
@@ -132,7 +138,7 @@
 		
 		if ([controlType isEqualToString:PVDPad])
 		{
-			CGFloat xPadding = 5;
+			CGFloat xPadding = safeAreaInsets.left + 5;
 			CGFloat bottomPadding = 16;
 			CGFloat dPadOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - controlSize.height - bottomPadding);
 			CGRect dPadFrame = CGRectMake(xPadding, dPadOriginY, controlSize.width, controlSize.height);
@@ -166,7 +172,7 @@
 		}
 		else if ([controlType isEqualToString:PVButtonGroup])
 		{
-			CGFloat xPadding = 5;
+			CGFloat xPadding = safeAreaInsets.right + 5;
 			CGFloat bottomPadding = 16;
 			
 			CGFloat buttonsOriginY = MIN(controlOriginY - bottomPadding, CGRectGetHeight(self.view.frame) - controlSize.height - bottomPadding);
@@ -202,8 +208,8 @@
 		}
 		else if ([controlType isEqualToString:PVLeftShoulderButton])
 		{
-			CGFloat xPadding = 10;
-			CGFloat yPadding = 10;
+			CGFloat xPadding = safeAreaInsets.left + 10;
+			CGFloat yPadding = safeAreaInsets.top + 10;
 
 			CGRect leftShoulderFrame = CGRectMake(xPadding, yPadding, controlSize.width, controlSize.height);
 			
@@ -226,8 +232,8 @@
 		}
 		else if ([controlType isEqualToString:PVRightShoulderButton])
 		{
-			CGFloat xPadding = 10;
-			CGFloat yPadding = 10;
+			CGFloat xPadding = safeAreaInsets.right + 10;
+			CGFloat yPadding = safeAreaInsets.top + 10;
 			CGRect rightShoulderFrame = CGRectMake(self.view.frame.size.width - controlSize.width - xPadding, yPadding, controlSize.width, controlSize.height);
 			
 			if (!self.rightShoulderButton)

--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -255,8 +255,11 @@
 		}
 		else if ([controlType isEqualToString:PVStartButton])
 		{
-			CGFloat yPadding = 10;
-			CGRect startFrame = CGRectMake((self.view.frame.size.width - controlSize.width) / 2, self.view.frame.size.height - controlSize.height - yPadding, controlSize.width, controlSize.height);
+            CGFloat yPadding = MAX(safeAreaInsets.bottom , 10);
+			CGRect startFrame = CGRectMake((self.view.frame.size.width - controlSize.width) / 2,
+                                           self.view.frame.size.height - controlSize.height - yPadding,
+                                           controlSize.width,
+                                           controlSize.height);
 			
 			if (!self.startButton)
 			{
@@ -277,8 +280,12 @@
 		}
 		else if ([controlType isEqualToString:PVSelectButton])
 		{
-			CGFloat yPadding = 10;
-			CGRect selectFrame = CGRectMake((self.view.frame.size.width - controlSize.width) / 2, self.view.frame.size.height - (controlSize.height * 2) - (yPadding * 2), controlSize.width, controlSize.height);
+            CGFloat yPadding = MAX(safeAreaInsets.bottom, 10);
+			CGFloat ySeparation = 10;
+			CGRect selectFrame = CGRectMake((self.view.frame.size.width - controlSize.width) / 2,
+                                            self.view.frame.size.height - yPadding - (controlSize.height * 2) - ySeparation,
+                                            controlSize.width,
+                                            controlSize.height);
 			
 			if (!self.selectButton)
 			{

--- a/Provenance/Emulator/PVEmulatorViewController.m
+++ b/Provenance/Emulator/PVEmulatorViewController.m
@@ -198,7 +198,6 @@ void uncaughtExceptionHandler(NSException *exception)
 	
 	CGFloat alpha = [[PVSettingsModel sharedInstance] controllerOpacity];
 	self.menuButton = [UIButton buttonWithType:UIButtonTypeCustom];
-	[self.menuButton setFrame:CGRectMake(([[self view] bounds].size.width - 62) / 2, 10, 62, 22)];
 	[self.menuButton setAutoresizingMask:UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin| UIViewAutoresizingFlexibleBottomMargin];
 	[self.menuButton setBackgroundImage:[UIImage imageNamed:@"button-thin"] forState:UIControlStateNormal];
 	[self.menuButton setBackgroundImage:[UIImage imageNamed:@"button-thin-pressed"] forState:UIControlStateHighlighted];
@@ -348,6 +347,18 @@ void uncaughtExceptionHandler(NSException *exception)
 		}];
 	}
 #endif
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    
+    UIEdgeInsets safeArea = UIEdgeInsetsZero;
+    if (@available(iOS 11.0, *)) {
+        safeArea = self.view.safeAreaInsets;
+    }
+    
+    [self.menuButton setFrame:CGRectMake(([[self view] bounds].size.width - 62) / 2, safeArea.top + 10, 62, 22)];
+
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Provenance/Emulator/PVEmulatorViewController.m
+++ b/Provenance/Emulator/PVEmulatorViewController.m
@@ -387,11 +387,15 @@ void uncaughtExceptionHandler(NSException *exception)
     return YES;
 }
 
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures
+{
+    return UIRectEdgeBottom;
+}
+
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
     return UIInterfaceOrientationMaskAll;
 }
-
 
 - (void)appWillEnterForeground:(NSNotification *)note
 {

--- a/Provenance/Emulator/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController.m
@@ -74,10 +74,15 @@
     [self setupCRTShader];
 }
 
-- (void)viewWillLayoutSubviews
+- (void)viewDidLayoutSubviews
 {
-    [super viewWillLayoutSubviews];
+    [super viewDidLayoutSubviews];
 
+    UIEdgeInsets parentSafeAreaInsets = UIEdgeInsetsZero;
+    if (@available(iOS 11.0, *)) {
+        parentSafeAreaInsets = self.parentViewController.view.safeAreaInsets;
+    }
+    
     if (!CGRectIsEmpty([self.emulatorCore screenRect]))
     {
         CGSize aspectSize = [self.emulatorCore aspectSize];
@@ -123,7 +128,7 @@
         CGPoint origin = CGPointMake(roundf((parentSize.width - width) / 2.0), 0);
         if (([self.traitCollection userInterfaceIdiom] == UIUserInterfaceIdiomPhone) && (parentSize.height > parentSize.width))
         {
-            origin.y = 40.0f; // directly below menu button at top of screen
+            origin.y = parentSafeAreaInsets.top + 40.0f; // directly below menu button at top of screen
         }
         else
         {


### PR DESCRIPTION
Fixes some layout issues on iPhone X.

**Landscape before / after:**

- Notch was overlapping either the d-pad and the button group, depending on orientation
- Start button overlapping home indicator

<img width="487" alt="landscape" src="https://user-images.githubusercontent.com/6288713/34313819-126b756c-e766-11e7-9c4e-6bac3795cff8.png">

**Portrait before / after:**

- Menu button was inaccessible as it was behind the notch
- Shoulder buttons high up in the status bar
- Start button overlapping home indicator

<img width="454" alt="portrait" src="https://user-images.githubusercontent.com/6288713/34313918-d766e2e8-e766-11e7-9bd1-20ac41415c71.png">

**Home Indicator**

I've also made some changes to how the home indicator is handled. There's basically 3 options:

- Have it always visible, and bright white, which is distracting.
- Use `prefersHomeIndicatorAutoHidden`, which hides it. Unfortunately it shows it again every time a button is pressed, which is more distracting.
- Use `preferredScreenEdgesDeferringSystemGestures` which shows it all the time, but makes it translucent (also requires two swipes to go home).

I thought we might be able to combine the two options to hide it all the time, but it's not possible, so I've gone for the last option as it's the most inconspicuous.



Note that the off-centre emulator in the screenshots isn't related to any changes in this PR, it seems to be an issue with the Playstation emu.

I've only tried Crash Bandicoot so far, but it runs perfectly on the iPhone X!