### PR TITLE
Fix for #646: Hide Home Indicator when gamepad/controller is connected (iPhone X) [Incomplete]

### DIFF
--- a/Provenance/Controller/PVControllerViewController.m
+++ b/Provenance/Controller/PVControllerViewController.m
@@ -22,10 +22,15 @@
 @interface PVControllerViewController ()
 
 @property (nonatomic, strong) NSArray *controlLayout;
+@property (nonatomic, assign) BOOL shouldHideHomeIndicator;
 
 @end
 
 @implementation PVControllerViewController
+
+-(BOOL)prefersHomeIndicatorAutoHidden{
+	return self.shouldHideHomeIndicator;
+}
 
 - (id)initWithControlLayout:(NSArray *)controlLayout systemIdentifier:(NSString *)systemIdentifier
 {
@@ -60,6 +65,10 @@
 - (void) viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
+	//Notifies UIKit that your view controller updated its preference regarding the Home Indicator
+	if (@available(iOS 11.0, *)) {
+		[self setNeedsUpdateOfHomeIndicatorAutoHidden];
+	}
 }
 
 - (void)viewDidLoad
@@ -345,6 +354,7 @@
         [self.rightShoulderButton setHidden:NO];
         [self.startButton setHidden:NO];
         [self.selectButton setHidden:NO];
+		self.shouldHideHomeIndicator = NO;
     }
 }
 
@@ -437,6 +447,7 @@ void AudioServicesPlaySystemSoundWithVibration(int, id, NSDictionary *);
         [self.startButton setHidden:YES];
         [self.selectButton setHidden:YES];
     }
+	self.shouldHideHomeIndicator = YES;
 }
 
 @end


### PR DESCRIPTION
Attempt to make Home Indicator hide when a controller is connected and overlay buttons are hidden. **Not currently working.** Home Indicator just flashes and fades back to something dimmer. I'm missing something…