### PR TITLE
Game Library Font Size Adjustment for readability/consistency (iOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,3 @@ build
 .svn
 xcuserdata
 *.mode1v3
-Provenance.xcodeproj/project.pbxproj
-Provenance/Provenance-Info.plist
-Provenance/Provenance-Info.plist
-ProvenanceTV/Info.plist
-ProvenanceTV/Provenance.entitlements
-ProvenanceTV/PVAppConstants.m
-TopShelf/TopShelf.entitlements

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ build
 .svn
 xcuserdata
 *.mode1v3
+Provenance.xcodeproj/project.pbxproj
+Provenance/Provenance-Info.plist
+Provenance/Provenance-Info.plist
+ProvenanceTV/Info.plist
+ProvenanceTV/Provenance.entitlements
+ProvenanceTV/PVAppConstants.m
+TopShelf/TopShelf.entitlements

--- a/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
+++ b/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
@@ -59,6 +59,10 @@ static const CGFloat LabelHeight = 44.0;
 		[_titleLabel setBackgroundColor:[UIColor clearColor]];
 		[_titleLabel setFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]];
 		[_titleLabel setTextAlignment:NSTextAlignmentCenter];
+#if !TARGET_OS_TV
+		//Downsize label text size for iPhone (matches iOS app icon text size)
+		_titleLabel.font=[_titleLabel.font fontWithSize:12];
+#endif
 		[_titleLabel setAdjustsFontSizeToFitWidth:YES];
 		[_titleLabel setMinimumScaleFactor:0.75];
 

--- a/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
+++ b/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
@@ -59,10 +59,6 @@ static const CGFloat LabelHeight = 44.0;
 		[_titleLabel setBackgroundColor:[UIColor clearColor]];
 		[_titleLabel setFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]];
 		[_titleLabel setTextAlignment:NSTextAlignmentCenter];
-#if !TARGET_OS_TV
-		//Downsize label text size for iPhone (matches iOS app icon text size)
-		_titleLabel.font=[_titleLabel.font fontWithSize:12];
-#endif
 		[_titleLabel setAdjustsFontSizeToFitWidth:YES];
 		[_titleLabel setMinimumScaleFactor:0.75];
 

--- a/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
+++ b/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
@@ -59,6 +59,9 @@ static const CGFloat LabelHeight = 44.0;
 		[_titleLabel setBackgroundColor:[UIColor clearColor]];
 		[_titleLabel setFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]];
 		[_titleLabel setTextAlignment:NSTextAlignmentCenter];
+#if !TARGET_OS_TV
+		_titleLabel.font=[_titleLabel.font fontWithSize:12];
+#endif
 		[_titleLabel setAdjustsFontSizeToFitWidth:YES];
 		[_titleLabel setMinimumScaleFactor:0.75];
 


### PR DESCRIPTION
Font size adjusted for game library cells for readability and consistency, less scale downs for long titles on iOS.

![458baf12-6b3e-4ad8-a4a1-1a39d27aa5d4](https://user-images.githubusercontent.com/3118097/34920490-5efc6a70-f928-11e7-8d7f-0948bd75c6ae.png)
![6cdaabef-49a3-49d7-b5b3-e3f3d2ec149f](https://user-images.githubusercontent.com/3118097/34920491-5f1b84a0-f928-11e7-9876-5379303be550.png)
![8faa37ed-47ff-4705-9611-8c09fc496ea2](https://user-images.githubusercontent.com/3118097/34920492-5f33fd28-f928-11e7-91c1-8a9a321b279b.png)

Should feel a bit more comfortable..