### PR TITLE
Mednafen improvements

### DIFF
--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -74,7 +74,8 @@ static inline OEIntRect OEIntRectMake(int x, int y, int width, int height)
 }
 
 static MDFNGI *game;
-static MDFN_Surface *surf;
+static MDFN_Surface *backBufferSurf;
+static MDFN_Surface *frontBufferSurf;
 
 namespace MDFN_IEN_VB
 {
@@ -892,7 +893,8 @@ static void mednafen_init(MednafenGameCore* current)
         free(inputBuffer[i]);
     }
 
-    delete surf;
+    delete backBufferSurf;
+    delete frontBufferSurf;
     
     if (_current == self) {
         _current = nil;
@@ -909,7 +911,7 @@ static void emulation_run() {
     rects[0] = ~0;
 
     EmulateSpecStruct spec = {0};
-    spec.surface = surf;
+    spec.surface = backBufferSurf;
     spec.SoundRate = current->sampleRate;
     spec.SoundBuf = sound_buf;
     spec.LineWidths = rects;
@@ -921,24 +923,10 @@ static void emulation_run() {
 
     current->mednafenCoreTiming = current->masterClock / spec.MasterCycles;
     
-    // Fix for game stutter. mednafenCoreTiming flutters on init before settling and we only read it
-    // after the first frame wot set the current->gameInterval in the super class. This work around
-    // resets the value after a few frames. -Joe M
-    static int fixCount = 0;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        // The looping counter wasn't enough sometimes, just adding a 2 second one time trigger to rsset frame timing
-        // Need to investigate more why this happens at all but this seems to resolve with no known side effects - jm
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            current->gameInterval = 1.0 / current->mednafenCoreTiming;
-        });
-    });
-    
-    if(fixCount < 10) {
-        current->gameInterval = 1.0 / current->mednafenCoreTiming;
-        NSLog(@"%f", current->mednafenCoreTiming);
-        fixCount++;
-    }
+    // Fix for game stutter. mednafenCoreTiming flutters on init before settling so
+    // now we reset the game speed each frame to make sure current->gameInterval
+    // is up to date while respecting the current game speed setting
+    [current setGameSpeed:[current gameSpeed]];
 
     if(current->systemType == psx)
     {
@@ -960,6 +948,11 @@ static void emulation_run() {
     current->videoOffsetY = spec.DisplayRect.y;
 
     update_audio_batch(spec.SoundBuf, spec.SoundBufSize);
+    
+    // Swap back and front buffers
+    MDFN_Surface *tempSurf = backBufferSurf;
+    backBufferSurf = frontBufferSurf;
+    frontBufferSurf = tempSurf;
 }
 
 - (BOOL)loadFileAtPath:(NSString *)path
@@ -1047,7 +1040,8 @@ static void emulation_run() {
     
     // BGRA pixel format
     MDFN_PixelFormat pix_fmt(MDFN_COLORSPACE_RGB, 16, 8, 0, 24);
-    surf = new MDFN_Surface(NULL, game->fb_width, game->fb_height, game->fb_width, pix_fmt);
+    backBufferSurf = new MDFN_Surface(NULL, game->fb_width, game->fb_height, game->fb_width, pix_fmt);
+    frontBufferSurf = new MDFN_Surface(NULL, game->fb_width, game->fb_height, game->fb_width, pix_fmt);
 
     masterClock = game->MasterClock >> 32;
 
@@ -1198,8 +1192,14 @@ static void emulation_run() {
 
 - (CGSize)bufferSize
 {
-    
-    return CGSizeMake(game->fb_width, game->fb_height);
+    if ( game == NULL )
+    {
+        return CGSizeMake(0, 0);
+    }
+    else
+    {
+        return CGSizeMake(game->fb_width, game->fb_height);
+    }
 }
 
 - (CGSize)aspectSize
@@ -1209,7 +1209,14 @@ static void emulation_run() {
 
 - (const void *)videoBuffer
 {
-    return surf->pixels;
+    if ( frontBufferSurf == NULL )
+    {
+        return NULL;
+    }
+    else
+    {
+        return frontBufferSurf->pixels;
+    }
 }
 
 - (GLenum)pixelFormat
@@ -1227,18 +1234,8 @@ static void emulation_run() {
     return GL_RGBA;
 }
 
-- (BOOL)wideScreen {
-    switch (systemType) {
-        case psx:
-            return YES;
-        case neogeo:
-        case lynx:
-        case pce:
-        case pcfx:
-        case vb:
-        case wswan:
-            return NO;
-    }
+- (BOOL)isDoubleBuffered {
+    return YES;
 }
 
 # pragma mark - Audio

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -948,11 +948,6 @@ static void emulation_run() {
     current->videoOffsetY = spec.DisplayRect.y;
 
     update_audio_batch(spec.SoundBuf, spec.SoundBufSize);
-    
-    // Swap back and front buffers
-    MDFN_Surface *tempSurf = backBufferSurf;
-    backBufferSurf = frontBufferSurf;
-    frontBufferSurf = tempSurf;
 }
 
 - (BOOL)loadFileAtPath:(NSString *)path
@@ -1236,6 +1231,13 @@ static void emulation_run() {
 
 - (BOOL)isDoubleBuffered {
     return YES;
+}
+
+- (void)swapBuffers
+{
+    MDFN_Surface *tempSurf = backBufferSurf;
+    backBufferSurf = frontBufferSurf;
+    frontBufferSurf = tempSurf;
 }
 
 # pragma mark - Audio

--- a/Mednafen/mednafen/state.cpp
+++ b/Mednafen/mednafen/state.cpp
@@ -675,6 +675,11 @@ bool MDFNI_SaveState(const char *fname, const char *suffix, const MDFN_Surface *
 
  try
  {
+  if(MDFNGameInfo == NULL)
+  {
+   throw MDFN_Error(0, _(""));
+  }
+     
   if(!MDFNGameInfo->StateAction)
   {
    throw MDFN_Error(0, _("Module \"%s\" doesn't support save states."), MDFNGameInfo->shortname);

--- a/PVSupport/PVSupport/PVEmulatorCore.h
+++ b/PVSupport/PVSupport/PVEmulatorCore.h
@@ -86,7 +86,7 @@ typedef NS_ENUM(NSInteger, GameSpeed) {
 - (CGRect)screenRect;
 - (CGSize)aspectSize;
 - (CGSize)bufferSize;
-- (BOOL)wideScreen;
+- (BOOL)isDoubleBuffered;
 - (GLenum)pixelFormat;
 - (GLenum)pixelType;
 - (GLenum)internalPixelFormat;

--- a/PVSupport/PVSupport/PVEmulatorCore.h
+++ b/PVSupport/PVSupport/PVEmulatorCore.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, PVEmulatorCoreErrorCode) {
 }
 
 @property (nonatomic, assign) double emulationFPS;
+@property (nonatomic, assign) double renderFPS;
 
 @property (nonatomic, copy) NSString *romName;
 @property (nonatomic, copy) NSString *saveStatesPath;
@@ -68,6 +69,9 @@ typedef NS_ENUM(NSInteger, GameSpeed) {
 @property (nonatomic, strong) GCController *controller2;
 
 @property (nonatomic, strong) NSLock  *emulationLoopThreadLock;
+@property (nonatomic, strong) NSCondition  *frontBufferCondition;
+@property (nonatomic, strong) NSLock  *frontBufferLock;
+@property (nonatomic, assign) BOOL isFrontBufferReady;
 
 - (void)startEmulation;
 - (void)resetEmulation;
@@ -87,6 +91,7 @@ typedef NS_ENUM(NSInteger, GameSpeed) {
 - (CGSize)aspectSize;
 - (CGSize)bufferSize;
 - (BOOL)isDoubleBuffered;
+- (void)swapBuffers;
 - (GLenum)pixelFormat;
 - (GLenum)pixelType;
 - (GLenum)internalPixelFormat;

--- a/PVSupport/PVSupport/PVEmulatorCore.m
+++ b/PVSupport/PVSupport/PVEmulatorCore.m
@@ -266,7 +266,7 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.jamsoftonline.EmulatorCore.Err
 	return defaultFrameInterval;
 }
 
-- (BOOL)wideScreen {
+- (BOOL)isDoubleBuffered {
     return NO;
 }
 

--- a/PVSupport/PVSupport/PVEmulatorCore.m
+++ b/PVSupport/PVSupport/PVEmulatorCore.m
@@ -37,6 +37,9 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.jamsoftonline.EmulatorCore.Err
 		NSUInteger count = [self audioBufferCount];
         ringBuffers = (__strong OERingBuffer **)calloc(count, sizeof(OERingBuffer *));
         self.emulationLoopThreadLock = [NSLock new];
+        self.frontBufferCondition = [NSCondition new];
+        self.frontBufferLock = [NSLock new];
+        [self setIsFrontBufferReady:NO];
         _gameSpeed = GameSpeedNormal;
 	}
 	
@@ -112,6 +115,7 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.jamsoftonline.EmulatorCore.Err
 
     // For FPS computation
     int frameCount = 0;
+    int framesTorn = 0;
     NSDate *fpsCounter = [NSDate date];
     
     //Setup Initial timing
@@ -138,6 +142,25 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.jamsoftonline.EmulatorCore.Err
 
         nextEmuTick += gameInterval;
         sleepTime = nextEmuTick - GetSecondsSince(origin);
+        
+        NSDate* bufferSwapLimit = [[NSDate date] dateByAddingTimeInterval:sleepTime];
+        if ([self.frontBufferLock tryLock] || [self.frontBufferLock lockBeforeDate:bufferSwapLimit]) {
+            [self swapBuffers];
+            [self.frontBufferLock unlock];
+            
+            [self.frontBufferCondition lock];
+            [self setIsFrontBufferReady:YES];
+            [self.frontBufferCondition signal];
+            [self.frontBufferCondition unlock];
+        } else {
+            [self swapBuffers];
+            ++framesTorn;
+            
+            [self setIsFrontBufferReady:YES];
+        }
+        
+        sleepTime = nextEmuTick - GetSecondsSince(origin);
+        
         if(sleepTime >= 0) {
             [NSThread sleepForTimeInterval:sleepTime];
         }
@@ -152,7 +175,9 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.jamsoftonline.EmulatorCore.Err
         NSTimeInterval timeSinceLastFPS = GetSecondsSince(fpsCounter);
         if (timeSinceLastFPS >= 0.5) {
             self.emulationFPS = (double)frameCount / timeSinceLastFPS;
+            self.renderFPS = (double)(frameCount - framesTorn) / timeSinceLastFPS;
             frameCount = 0;
+            framesTorn = 0;
             fpsCounter = [NSDate date];
         }
         
@@ -185,9 +210,11 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.jamsoftonline.EmulatorCore.Err
 
 - (void)setFramerateMultiplier:(CGFloat)framerateMultiplier
 {
-	_framerateMultiplier = framerateMultiplier;
-
-    NSLog(@"multiplier: %.1f", framerateMultiplier);
+    if ( _framerateMultiplier != framerateMultiplier )
+    {
+        _framerateMultiplier = framerateMultiplier;
+        NSLog(@"multiplier: %.1f", framerateMultiplier);
+    }
     gameInterval = 1.0 / ([self frameInterval] * framerateMultiplier);
 }
 
@@ -268,6 +295,11 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.jamsoftonline.EmulatorCore.Err
 
 - (BOOL)isDoubleBuffered {
     return NO;
+}
+
+- (void)swapBuffers
+{
+    NSAssert(!self.isDoubleBuffered, @"Cores that are double-buffered must implement swapBuffers!");
 }
 
 #pragma mark - Audio

--- a/Provenance/Emulator/PVEmulatorViewController.m
+++ b/Provenance/Emulator/PVEmulatorViewController.m
@@ -231,7 +231,11 @@ void uncaughtExceptionHandler(NSException *exception)
         if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
             // Block-based NSTimer method is only available on iOS 10 and later
             self.fpsTimer = [NSTimer scheduledTimerWithTimeInterval:0.5 repeats:YES block:^(NSTimer * _Nonnull timer) {
-                self.fpsLabel.text = [NSString stringWithFormat:@"%2.02f", self.emulatorCore.emulationFPS];
+                if (self.emulatorCore.renderFPS == self.emulatorCore.emulationFPS) {
+                    self.fpsLabel.text = [NSString stringWithFormat:@"%2.02f", self.emulatorCore.renderFPS];
+                } else {
+                    self.fpsLabel.text = [NSString stringWithFormat:@"%2.02f (%2.02f)", self.emulatorCore.renderFPS, self.emulatorCore.emulationFPS];
+                }
             }];
         } else {
 #endif

--- a/Provenance/Resources/shader_crt_fragment.glsl
+++ b/Provenance/Resources/shader_crt_fragment.glsl
@@ -14,14 +14,14 @@
 // Please take and use, change, or whatever.
 
 #ifdef GL_ES
-precision highp float;
+precision mediump float;
 #endif
 
 #if __VERSION__ < 300
 #define texture texture2D
 #endif
 
-varying vec2 fTexCoord;
+varying highp vec2 fTexCoord;
 
 uniform vec4 DisplayRect;
 uniform sampler2D EmulatedImage;
@@ -29,55 +29,61 @@ uniform vec2 EmulatedImageSize;
 uniform vec2 FinalRes;
 
 #define FINAL_RES FinalRes
-#define INPUT_RES DisplayRect.zw
 #define INPUT_SAMPLER EmulatedImage
-#define UV_TO_INPUTCOORD( uv ) ( ( DisplayRect.xy + uv * DisplayRect.zw ) / EmulatedImageSize )
+// These are to convert input texture coordinates to UV (0-1) space and back.
+#define INPUTCOORD_TO_UV( inputCoord ) ( inputCoord / DisplayRect.zw * EmulatedImageSize - DisplayRect.xy / DisplayRect.zw )
+#define UV_TO_INPUTCOORD( uv ) ( DisplayRect.xy / EmulatedImageSize + uv / EmulatedImageSize * DisplayRect.zw )
 
 #define USE_SCANLINES 1
 #define USE_SHADOWMASK 1
 
 #define BLOOM_AMOUNT 2.0
 #define MIN_BRIGHTNESS 0.003
-#define SCANLINES_ALLOWED ( FINAL_RES.y >= INPUT_RES.y * 3.0 )
+#define ROWS_OF_RESOLUTION 480.0
+#define SCANLINES_ALLOWED ( FINAL_RES.y >= ROWS_OF_RESOLUTION / 2.0 * 4.0 )
 #define SCANLINE_HARDNESS 4.0
 #define SCANLINE_MIN_BRIGHTNESS vec3( 0.25, 0.0, 0.25 )
 #define SHADOW_MASK_HARDNESS 16.0
+#define TVL 360.0
 #define WARP_EDGE_HARDNESS 256.0
 #define WARP_X ( 1.0 / 64.0 )
 #define WARP_Y ( 1.0 / 24.0 )
 
 float ToLinear1(float c){return(c<=0.04045)?c/12.92:pow((c+0.055)/1.055,2.4);}
-vec3 ToLinear(vec3 c){return vec3(ToLinear1(c.r),ToLinear1(c.g),ToLinear1(c.b));}
+vec3 ToLinear(vec3 c){return c*c;}//return vec3(ToLinear1(c.r),ToLinear1(c.g),ToLinear1(c.b));}
 
 float ToSrgb1(float c){return(c<0.0031308?c*12.92:1.055*pow(c,0.41666)-0.055);}
-vec3 ToSrgb(vec3 c){return vec3(ToSrgb1(c.r),ToSrgb1(c.g),ToSrgb1(c.b));}
+vec3 ToSrgb(vec3 c){return sqrt(c);}//return vec3(ToSrgb1(c.r),ToSrgb1(c.g),ToSrgb1(c.b));}
 
-vec2 Warp( vec2 uv )
+highp vec2 Warp( highp vec2 uv )
 {
     uv = uv * 2.0 - 1.0;
     uv *= vec2( 1.0 + ( uv.y * uv.y ) * WARP_X, 1.0 + ( uv.x * uv.x ) * WARP_Y );
     return uv * 0.5 + 0.5;
 }
 
-vec3 getShadowMaskRGB( vec2 uv )
+vec2 getShadowMaskRes()
 {
-#if USE_SHADOWMASK
     vec2 shadowMaskRes;
-    if ( FINAL_RES.y / 3.0 < 480.0 )
+    if ( FINAL_RES.y / 3.0 < TVL * 2.0 )
     {
         shadowMaskRes = FINAL_RES / 3.0;
     }
     else
     {
-        shadowMaskRes = vec2( FINAL_RES.x / FINAL_RES.y * 480.0, 480.0 );
+        shadowMaskRes = vec2( FINAL_RES.x / FINAL_RES.y * TVL, TVL );
     }
-    vec2 pixelCoord = uv * shadowMaskRes * vec2( 3.0, 3.0 );
-    
-    vec3 shadowMaskRGB;
-    shadowMaskRGB.r = abs( mod( pixelCoord.x + 1.5, 3.0 ) - 1.5 ) / 1.5;
-    shadowMaskRGB.g = abs( mod( pixelCoord.x + 0.5, 3.0 ) - 1.5 ) / 1.5;
-    shadowMaskRGB.b = abs( mod( pixelCoord.x + 2.5, 3.0 ) - 1.5 ) / 1.5;
-    shadowMaskRGB = min( shadowMaskRGB, 1.0 );
+    return shadowMaskRes;
+}
+
+vec3 getShadowMaskRGB( highp vec2 uv )
+{
+#if USE_SHADOWMASK
+    vec2 shadowMaskRes = getShadowMaskRes();
+    highp vec2 pixelCoord = uv * shadowMaskRes * vec2( 3.0, 3.0 );
+    highp vec3 shadowMaskCoord = vec3( pixelCoord.x + 1.0, pixelCoord.x + 0.0, pixelCoord.x + 2.0 );
+    //vec3 shadowMaskRGB = clamp( abs( mod( shadowMaskCoord, 3.0 ) - 1.5 ) - 0.5, 0.0, 1.0 );
+    vec3 shadowMaskRGB = abs( mod( shadowMaskCoord, 3.0 ) - 1.5 ) / 1.5;
     shadowMaskRGB = exp2( shadowMaskRGB * shadowMaskRGB * -SHADOW_MASK_HARDNESS );
     return shadowMaskRGB;
 #else
@@ -85,42 +91,42 @@ vec3 getShadowMaskRGB( vec2 uv )
 #endif
 }
 
-vec3 sampleRGB( vec2 uv )
+vec3 sampleRGB( highp vec2 uv, highp vec2 warpedUV )
 {
-    vec2 warpedUV = Warp( uv );
-    float edgeMask = 1.0 - exp2( ( 1.0 - max( abs( warpedUV.x - 0.5 ), abs( warpedUV.y - 0.5 ) ) / 0.5 ) * -WARP_EDGE_HARDNESS );
-    float inputSpaceY = warpedUV.y * INPUT_RES.y;
-    
     vec3 inputSample = ToLinear( texture( INPUT_SAMPLER, UV_TO_INPUTCOORD( warpedUV ) ).rgb );
     
     vec3 scanlineMultiplier = vec3( 1.0 );
 #if USE_SCANLINES
     if ( SCANLINES_ALLOWED )
     {
-        float scanlineY = mod( inputSpaceY, 1.0 );
+        float scanlineY = mod( warpedUV.y, 2.0 / ROWS_OF_RESOLUTION ) / ( 2.0 / ROWS_OF_RESOLUTION );
         float scanlineDistance = abs( scanlineY - 0.5 ) / 0.5;
         float scanlineCoverage = exp2( scanlineDistance * scanlineDistance * -SCANLINE_HARDNESS );
         scanlineMultiplier = mix( SCANLINE_MIN_BRIGHTNESS, vec3( 1.0 ), scanlineCoverage );
     }
 #endif
     
-    return max( inputSample * scanlineMultiplier, vec3( MIN_BRIGHTNESS ) ) * getShadowMaskRGB( uv ) * edgeMask;
+    return max( inputSample * scanlineMultiplier, vec3( MIN_BRIGHTNESS ) ) * getShadowMaskRGB( uv );
 }
 
-vec3 sampleRow( vec2 uv )
+vec3 sampleRow( highp vec2 uv, vec3 centerTap )
 {
-    return sampleRGB( uv ) * 0.5
-    + sampleRGB( uv + vec2( -1.0 / FINAL_RES.x, 0.0 ) ) * 0.25
-    + sampleRGB( uv + vec2( 1.0 / FINAL_RES.x, 0.0 ) ) * 0.25;
+    highp vec2 leftUV = uv + vec2( -1.0 / FINAL_RES.x, 0.0 );
+    highp vec2 rightUV = uv + vec2( 1.0 / FINAL_RES.x, 0.0 );
+    return centerTap * 0.5
+    + sampleRGB( leftUV, Warp( leftUV ) ) * 0.25
+    + sampleRGB( rightUV, Warp( rightUV ) ) * 0.25;
 }
 
-vec3 sampleCol( vec2 uv )
+vec3 sampleCol( highp vec2 uv, vec3 centerTap )
 {
-    return sampleRow( uv );
+    return sampleRow( uv, centerTap );
 }
 
-vec3 crtFilter( vec2 uv )
+vec3 crtFilter( highp vec2 uv )
 {
+    highp vec2 warpedUV = Warp( uv );
+    float edgeMask = 1.0 - exp2( ( 1.0 - max( abs( warpedUV.x - 0.5 ), abs( warpedUV.y - 0.5 ) ) / 0.5 ) * -WARP_EDGE_HARDNESS );
     float bloomAmount = BLOOM_AMOUNT;
 #if USE_SCANLINES
     if ( SCANLINES_ALLOWED )
@@ -128,12 +134,12 @@ vec3 crtFilter( vec2 uv )
         bloomAmount *= 2.0;
     }
 #endif
-    return ToSrgb( sampleRGB( uv ) + sampleCol( uv ) * bloomAmount );
+    vec3 centerTap = sampleRGB( uv, warpedUV );
+    return ToSrgb( ( centerTap + sampleCol( uv, centerTap ) * bloomAmount ) * edgeMask );
 }
 
 void main( void )
 {
-    vec2 uv = ( fTexCoord * EmulatedImageSize - DisplayRect.xy ) / DisplayRect.zw;
-    gl_FragColor.rgb = crtFilter( uv );
+    gl_FragColor.rgb = crtFilter( INPUTCOORD_TO_UV( fTexCoord ) );
     gl_FragColor.a = 1.0;
 }

--- a/Provenance/Resources/shader_crt_fragment.glsl
+++ b/Provenance/Resources/shader_crt_fragment.glsl
@@ -23,14 +23,15 @@ precision highp float;
 
 varying vec2 fTexCoord;
 
+uniform vec4 DisplayRect;
 uniform sampler2D EmulatedImage;
-uniform vec4 EmulatedImageRes;
+uniform vec2 EmulatedImageSize;
 uniform vec2 FinalRes;
 
 #define FINAL_RES FinalRes
-#define INPUT_RES EmulatedImageRes.xy
+#define INPUT_RES DisplayRect.zw
 #define INPUT_SAMPLER EmulatedImage
-#define UV_TO_INPUTCOORD( uv ) ( uv / EmulatedImageRes.zw * EmulatedImageRes.xy )
+#define UV_TO_INPUTCOORD( uv ) ( ( DisplayRect.xy + uv * DisplayRect.zw ) / EmulatedImageSize )
 
 #define USE_SCANLINES 1
 #define USE_SHADOWMASK 1
@@ -132,7 +133,7 @@ vec3 crtFilter( vec2 uv )
 
 void main( void )
 {
-    vec2 uv = fTexCoord / EmulatedImageRes.xy * EmulatedImageRes.zw;
+    vec2 uv = ( fTexCoord * EmulatedImageSize - DisplayRect.xy ) / DisplayRect.zw;
     gl_FragColor.rgb = crtFilter( uv );
     gl_FragColor.a = 1.0;
 }

--- a/ProvenanceTV/Resources/shader_crt_fragment.glsl
+++ b/ProvenanceTV/Resources/shader_crt_fragment.glsl
@@ -23,14 +23,15 @@ precision highp float;
 
 varying vec2 fTexCoord;
 
+uniform vec4 DisplayRect;
 uniform sampler2D EmulatedImage;
-uniform vec4 EmulatedImageRes;
+uniform vec2 EmulatedImageSize;
 uniform vec2 FinalRes;
 
 #define FINAL_RES FinalRes
-#define INPUT_RES EmulatedImageRes.xy
+#define INPUT_RES DisplayRect.zw
 #define INPUT_SAMPLER EmulatedImage
-#define UV_TO_INPUTCOORD( uv ) ( uv / EmulatedImageRes.zw * EmulatedImageRes.xy )
+#define UV_TO_INPUTCOORD( uv ) ( ( DisplayRect.xy + uv * DisplayRect.zw ) / EmulatedImageSize )
 
 #define USE_SCANLINES 1
 #define USE_SHADOWMASK 1
@@ -132,7 +133,8 @@ vec3 crtFilter( vec2 uv )
 
 void main( void )
 {
-    vec2 uv = fTexCoord / EmulatedImageRes.xy * EmulatedImageRes.zw;
+    vec2 uv = ( fTexCoord * EmulatedImageSize - DisplayRect.xy ) / DisplayRect.zw;
     gl_FragColor.rgb = crtFilter( uv );
     gl_FragColor.a = 1.0;
 }
+

--- a/ProvenanceTV/Resources/shader_crt_fragment.glsl
+++ b/ProvenanceTV/Resources/shader_crt_fragment.glsl
@@ -14,14 +14,14 @@
 // Please take and use, change, or whatever.
 
 #ifdef GL_ES
-precision highp float;
+precision mediump float;
 #endif
 
 #if __VERSION__ < 300
 #define texture texture2D
 #endif
 
-varying vec2 fTexCoord;
+varying highp vec2 fTexCoord;
 
 uniform vec4 DisplayRect;
 uniform sampler2D EmulatedImage;
@@ -29,55 +29,61 @@ uniform vec2 EmulatedImageSize;
 uniform vec2 FinalRes;
 
 #define FINAL_RES FinalRes
-#define INPUT_RES DisplayRect.zw
 #define INPUT_SAMPLER EmulatedImage
-#define UV_TO_INPUTCOORD( uv ) ( ( DisplayRect.xy + uv * DisplayRect.zw ) / EmulatedImageSize )
+// These are to convert input texture coordinates to UV (0-1) space and back.
+#define INPUTCOORD_TO_UV( inputCoord ) ( inputCoord / DisplayRect.zw * EmulatedImageSize - DisplayRect.xy / DisplayRect.zw )
+#define UV_TO_INPUTCOORD( uv ) ( DisplayRect.xy / EmulatedImageSize + uv / EmulatedImageSize * DisplayRect.zw )
 
 #define USE_SCANLINES 1
 #define USE_SHADOWMASK 1
 
 #define BLOOM_AMOUNT 2.0
 #define MIN_BRIGHTNESS 0.003
-#define SCANLINES_ALLOWED ( FINAL_RES.y >= INPUT_RES.y * 3.0 )
+#define ROWS_OF_RESOLUTION 480.0
+#define SCANLINES_ALLOWED ( FINAL_RES.y >= ROWS_OF_RESOLUTION / 2.0 * 4.0 )
 #define SCANLINE_HARDNESS 4.0
 #define SCANLINE_MIN_BRIGHTNESS vec3( 0.25, 0.0, 0.25 )
 #define SHADOW_MASK_HARDNESS 16.0
+#define TVL 360.0
 #define WARP_EDGE_HARDNESS 256.0
 #define WARP_X ( 1.0 / 64.0 )
 #define WARP_Y ( 1.0 / 24.0 )
 
 float ToLinear1(float c){return(c<=0.04045)?c/12.92:pow((c+0.055)/1.055,2.4);}
-vec3 ToLinear(vec3 c){return vec3(ToLinear1(c.r),ToLinear1(c.g),ToLinear1(c.b));}
+vec3 ToLinear(vec3 c){return c*c;}//return vec3(ToLinear1(c.r),ToLinear1(c.g),ToLinear1(c.b));}
 
 float ToSrgb1(float c){return(c<0.0031308?c*12.92:1.055*pow(c,0.41666)-0.055);}
-vec3 ToSrgb(vec3 c){return vec3(ToSrgb1(c.r),ToSrgb1(c.g),ToSrgb1(c.b));}
+vec3 ToSrgb(vec3 c){return sqrt(c);}//return vec3(ToSrgb1(c.r),ToSrgb1(c.g),ToSrgb1(c.b));}
 
-vec2 Warp( vec2 uv )
+highp vec2 Warp( highp vec2 uv )
 {
     uv = uv * 2.0 - 1.0;
     uv *= vec2( 1.0 + ( uv.y * uv.y ) * WARP_X, 1.0 + ( uv.x * uv.x ) * WARP_Y );
     return uv * 0.5 + 0.5;
 }
 
-vec3 getShadowMaskRGB( vec2 uv )
+vec2 getShadowMaskRes()
 {
-#if USE_SHADOWMASK
     vec2 shadowMaskRes;
-    if ( FINAL_RES.y / 3.0 < 480.0 )
+    if ( FINAL_RES.y / 3.0 < TVL * 2.0 )
     {
         shadowMaskRes = FINAL_RES / 3.0;
     }
     else
     {
-        shadowMaskRes = vec2( FINAL_RES.x / FINAL_RES.y * 480.0, 480.0 );
+        shadowMaskRes = vec2( FINAL_RES.x / FINAL_RES.y * TVL, TVL );
     }
-    vec2 pixelCoord = uv * shadowMaskRes * vec2( 3.0, 3.0 );
-    
-    vec3 shadowMaskRGB;
-    shadowMaskRGB.r = abs( mod( pixelCoord.x + 1.5, 3.0 ) - 1.5 ) / 1.5;
-    shadowMaskRGB.g = abs( mod( pixelCoord.x + 0.5, 3.0 ) - 1.5 ) / 1.5;
-    shadowMaskRGB.b = abs( mod( pixelCoord.x + 2.5, 3.0 ) - 1.5 ) / 1.5;
-    shadowMaskRGB = min( shadowMaskRGB, 1.0 );
+    return shadowMaskRes;
+}
+
+vec3 getShadowMaskRGB( highp vec2 uv )
+{
+#if USE_SHADOWMASK
+    vec2 shadowMaskRes = getShadowMaskRes();
+    highp vec2 pixelCoord = uv * shadowMaskRes * vec2( 3.0, 3.0 );
+    highp vec3 shadowMaskCoord = vec3( pixelCoord.x + 1.0, pixelCoord.x + 0.0, pixelCoord.x + 2.0 );
+    //vec3 shadowMaskRGB = clamp( abs( mod( shadowMaskCoord, 3.0 ) - 1.5 ) - 0.5, 0.0, 1.0 );
+    vec3 shadowMaskRGB = abs( mod( shadowMaskCoord, 3.0 ) - 1.5 ) / 1.5;
     shadowMaskRGB = exp2( shadowMaskRGB * shadowMaskRGB * -SHADOW_MASK_HARDNESS );
     return shadowMaskRGB;
 #else
@@ -85,42 +91,42 @@ vec3 getShadowMaskRGB( vec2 uv )
 #endif
 }
 
-vec3 sampleRGB( vec2 uv )
+vec3 sampleRGB( highp vec2 uv, highp vec2 warpedUV )
 {
-    vec2 warpedUV = Warp( uv );
-    float edgeMask = 1.0 - exp2( ( 1.0 - max( abs( warpedUV.x - 0.5 ), abs( warpedUV.y - 0.5 ) ) / 0.5 ) * -WARP_EDGE_HARDNESS );
-    float inputSpaceY = warpedUV.y * INPUT_RES.y;
-    
     vec3 inputSample = ToLinear( texture( INPUT_SAMPLER, UV_TO_INPUTCOORD( warpedUV ) ).rgb );
     
     vec3 scanlineMultiplier = vec3( 1.0 );
 #if USE_SCANLINES
     if ( SCANLINES_ALLOWED )
     {
-        float scanlineY = mod( inputSpaceY, 1.0 );
+        float scanlineY = mod( warpedUV.y, 2.0 / ROWS_OF_RESOLUTION ) / ( 2.0 / ROWS_OF_RESOLUTION );
         float scanlineDistance = abs( scanlineY - 0.5 ) / 0.5;
         float scanlineCoverage = exp2( scanlineDistance * scanlineDistance * -SCANLINE_HARDNESS );
         scanlineMultiplier = mix( SCANLINE_MIN_BRIGHTNESS, vec3( 1.0 ), scanlineCoverage );
     }
 #endif
     
-    return max( inputSample * scanlineMultiplier, vec3( MIN_BRIGHTNESS ) ) * getShadowMaskRGB( uv ) * edgeMask;
+    return max( inputSample * scanlineMultiplier, vec3( MIN_BRIGHTNESS ) ) * getShadowMaskRGB( uv );
 }
 
-vec3 sampleRow( vec2 uv )
+vec3 sampleRow( highp vec2 uv, vec3 centerTap )
 {
-    return sampleRGB( uv ) * 0.5
-    + sampleRGB( uv + vec2( -1.0 / FINAL_RES.x, 0.0 ) ) * 0.25
-    + sampleRGB( uv + vec2( 1.0 / FINAL_RES.x, 0.0 ) ) * 0.25;
+    highp vec2 leftUV = uv + vec2( -1.0 / FINAL_RES.x, 0.0 );
+    highp vec2 rightUV = uv + vec2( 1.0 / FINAL_RES.x, 0.0 );
+    return centerTap * 0.5
+    + sampleRGB( leftUV, Warp( leftUV ) ) * 0.25
+    + sampleRGB( rightUV, Warp( rightUV ) ) * 0.25;
 }
 
-vec3 sampleCol( vec2 uv )
+vec3 sampleCol( highp vec2 uv, vec3 centerTap )
 {
-    return sampleRow( uv );
+    return sampleRow( uv, centerTap );
 }
 
-vec3 crtFilter( vec2 uv )
+vec3 crtFilter( highp vec2 uv )
 {
+    highp vec2 warpedUV = Warp( uv );
+    float edgeMask = 1.0 - exp2( ( 1.0 - max( abs( warpedUV.x - 0.5 ), abs( warpedUV.y - 0.5 ) ) / 0.5 ) * -WARP_EDGE_HARDNESS );
     float bloomAmount = BLOOM_AMOUNT;
 #if USE_SCANLINES
     if ( SCANLINES_ALLOWED )
@@ -128,13 +134,12 @@ vec3 crtFilter( vec2 uv )
         bloomAmount *= 2.0;
     }
 #endif
-    return ToSrgb( sampleRGB( uv ) + sampleCol( uv ) * bloomAmount );
+    vec3 centerTap = sampleRGB( uv, warpedUV );
+    return ToSrgb( ( centerTap + sampleCol( uv, centerTap ) * bloomAmount ) * edgeMask );
 }
 
 void main( void )
 {
-    vec2 uv = ( fTexCoord * EmulatedImageSize - DisplayRect.xy ) / DisplayRect.zw;
-    gl_FragColor.rgb = crtFilter( uv );
+    gl_FragColor.rgb = crtFilter( INPUTCOORD_TO_UV( fTexCoord ) );
     gl_FragColor.a = 1.0;
 }
-


### PR DESCRIPTION
Posting this PR for consideration as discussed in #566 

Renderer will now function correctly when an emulator core does not write its final image to the top-left of the frame buffer, as is the case with PSX in Mednafen. As a result, I've removed the "wideScreen" flag as I believe that was hack to try and correct this behavior.

Cores can now implement double buffering and return YES from isDoubleBuffered to have the renderer take advantage of that fact and render in parallel to the emulation when needed. Mednafen now has double buffering implemented.

Replaced the mednafenCoreTiming hack with a call to setGameSpeed each frame as this will ensure that gameInterval stays in sync and it seems to fix various speed issues I was getting with PSX emulation.

Added some NULL checks to fix crashes I ran into in cases where a Mednafen ROM failed to load.